### PR TITLE
feature: Create src/sim/ entry point and tests/sim/ placeholder

### DIFF
--- a/src/sim/index.ts
+++ b/src/sim/index.ts
@@ -1,0 +1,6 @@
+// Deterministic, render-free simulation logic lives in this directory.
+// export * from './world';
+// export * from './voxel';
+// export * from './inventory';
+// export * from './crafting';
+// export * from './save';

--- a/tests/sim/index.test.ts
+++ b/tests/sim/index.test.ts
@@ -1,0 +1,5 @@
+import { describe, it } from 'vitest';
+
+describe('sim module', () => {
+  it.todo('re-exports world, voxel, inventory, crafting, save');
+});


### PR DESCRIPTION
## Create src/sim/ entry point and tests/sim/ placeholder

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #41

### Changes
Create src/sim/index.ts as the simulation module barrel. Per CONSTITUTION.md, this module owns deterministic systems: world generation, voxel data, inventory, crafting, and save/load. The file should be a TypeScript barrel that lists the planned submodule re-exports as commented placeholders (one comment per submodule: world, voxel, inventory, crafting, save) — e.g. `// export * from './world';` for each, commented out because the submodules do not exist yet. Add a short top-of-file comment stating that this directory contains deterministic, render-free logic. Mirror this with tests/sim/index.test.ts containing a placeholder using vitest: `import { describe, it } from 'vitest'; describe('sim module', () => { it.todo('re-exports world, voxel, inventory, crafting, save'); });`. The placeholder must use it.todo so the suite passes once vitest is configured. Do not import anything that does not yet exist — keep the active code empty.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*