### PR TITLE
feature: Add Vite, Vitest, Playwright configs and index.html entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blockstead</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test";
+
+const port = 5173;
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  use: {
+    baseURL
+  },
+  webServer: {
+    command: "pnpm dev -- --host 127.0.0.1",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        browserName: "chromium"
+      }
+    }
+  ]
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  root: ".",
+  build: {
+    outDir: "dist"
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: false,
+    include: ["tests/**/*.test.ts", "src/**/*.test.ts"],
+    exclude: ["node_modules/**", "tests/e2e/**"]
+  }
+});


### PR DESCRIPTION
## Add Vite, Vitest, Playwright configs and index.html entry

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #45

### Changes
Add the build/test tooling configs that wire pnpm dev/build/test to the scaffold. vite.config.ts: minimal Vite config for a vanilla TS app, root at repo root, builds to dist/. vitest.config.ts: environment 'jsdom', includes tests/**/*.test.ts and src/**/*.test.ts, globals false (use explicit imports), excludes node_modules and tests/e2e/. playwright.config.ts: testDir='tests/e2e', webServer command 'pnpm dev' on a known port (e.g. 5173) with reuseExistingServer locally, baseURL matching, single chromium project. index.html: minimal HTML with <div id="app"></div> placeholder, <script type="module" src="/src/main.ts"></script>, and a <title> reflecting the project. Do NOT create any tests/e2e files yet — only the directory referenced in playwright.config.ts. The smoke unit test lives in the next task.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*