### PR TITLE
feature: Create src/hud/ entry point and tests/hud/ placeholder

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -1,0 +1,10 @@
+// HUD components must surface state through DOM labels and stable data
+// attributes rather than canvas-only rendering so Playwright can assert the
+// selected block, inventory counts, active recipe, save status, and player coordinates.
+
+// export * from './hotbar';
+// export * from './inventoryPanel';
+// export * from './coordinatesLabel';
+// export * from './saveStatus';
+
+export {};

--- a/tests/hud/index.test.ts
+++ b/tests/hud/index.test.ts
@@ -1,0 +1,5 @@
+import { describe, it } from 'vitest';
+
+describe('hud module', () => {
+  it.todo('exposes hotbar, inventory, coordinates, and save-status indicators');
+});


### PR DESCRIPTION
## Create src/hud/ entry point and tests/hud/ placeholder

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #40

### Changes
Create src/hud/index.ts as the HUD module barrel. Per CONSTITUTION.md quality standards, the HUD must expose test-friendly state via DOM labels and stable data attributes — selected block, inventory counts, active recipe, save status, and player coordinates. The file should be a TypeScript barrel with commented re-export placeholders for the planned HUD pieces (e.g. `// export * from './hotbar';`, `// export * from './inventoryPanel';`, `// export * from './coordinatesLabel';`, `// export * from './saveStatus';`) plus a header comment noting that HUD components must surface state through DOM/data attributes rather than canvas-only rendering, so Playwright can assert on them. Mirror with tests/hud/index.test.ts: `import { describe, it } from 'vitest'; describe('hud module', () => { it.todo('exposes hotbar, inventory, coordinates, and save-status indicators'); });`.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*