### PR TITLE
feature: Create src/render/ entry point and tests/render/ placeholder

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,0 +1,8 @@
+// Presentation-only Three.js rendering helpers live in this directory.
+// Scene, camera, and chunk mesh helpers must not own deterministic simulation state.
+
+// export * from './scene';
+// export * from './camera';
+// export * from './chunkMesh';
+
+export {};

--- a/tests/render/index.test.ts
+++ b/tests/render/index.test.ts
@@ -1,0 +1,5 @@
+import { describe, it } from 'vitest';
+
+describe('render module', () => {
+  it.todo('exposes Three.js scene, camera, and mesh helpers');
+});


### PR DESCRIPTION
## Create src/render/ entry point and tests/render/ placeholder

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #43

### Changes
Create src/render/index.ts as the rendering module barrel. Per CONSTITUTION.md, this module owns Three.js scene, camera, and mesh helpers — presentation only, never simulation state. The file should be a TypeScript barrel that lists planned helpers as commented placeholders (e.g. `// export * from './scene';`, `// export * from './camera';`, `// export * from './chunkMesh';`) and a short header comment stating that this directory contains presentation-only helpers and must not own deterministic state. Mirror with tests/render/index.test.ts: `import { describe, it } from 'vitest'; describe('render module', () => { it.todo('exposes Three.js scene, camera, and mesh helpers'); });`.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*