### PR TITLE
feature: Create src/input/ entry point and tests/input/ placeholder

### DIFF
--- a/src/input/index.ts
+++ b/src/input/index.ts
@@ -1,0 +1,8 @@
+// Input adapters must not import from src/sim or src/render.
+// This layer translates browser events into deterministic intent objects only.
+
+// export * from './keyboard';
+// export * from './mouse';
+// export * from './pointerLock';
+
+export {};

--- a/tests/input/index.test.ts
+++ b/tests/input/index.test.ts
@@ -1,0 +1,5 @@
+import { describe, it } from 'vitest';
+
+describe('input module', () => {
+  it.todo('adapts keyboard and mouse events into deterministic intents');
+});


### PR DESCRIPTION
## Create src/input/ entry point and tests/input/ placeholder

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #42

### Changes
Create src/input/index.ts as the input adapter barrel. Per CONSTITUTION.md, this module owns keyboard and mouse adapters that translate browser events into deterministic intents the sim layer can consume. The file should be a TypeScript barrel with commented re-export placeholders for the planned adapters (e.g. `// export * from './keyboard';`, `// export * from './mouse';`, `// export * from './pointerLock';`) and a header comment stating this layer must not import from src/sim or src/render — it should expose intent objects only. Mirror with tests/input/index.test.ts: `import { describe, it } from 'vitest'; describe('input module', () => { it.todo('adapts keyboard and mouse events into deterministic intents'); });`.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*