### PR TITLE
feature: Add Three.js bootstrap (src/main.ts, src/app.ts) and tests/smoke.test.ts

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,44 @@
+import * as THREE from "three";
+
+export interface AppRenderer {
+  readonly domElement: HTMLCanvasElement;
+  render(scene: THREE.Scene, camera: THREE.Camera): void;
+  setSize(width: number, height: number, updateStyle?: boolean): void;
+}
+
+export interface App {
+  readonly scene: THREE.Scene;
+  readonly camera: THREE.PerspectiveCamera;
+  readonly renderer: AppRenderer;
+  step(dt: number): void;
+}
+
+export type RendererFactory = (canvas?: HTMLCanvasElement) => AppRenderer;
+
+export interface CreateAppOptions {
+  readonly canvas?: HTMLCanvasElement;
+  readonly rendererFactory?: RendererFactory;
+}
+
+const createRenderer: RendererFactory = (canvas) =>
+  new THREE.WebGLRenderer({
+    antialias: true,
+    canvas
+  });
+
+export function createApp(options: CreateAppOptions = {}): App {
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 1000);
+  const renderer = (options.rendererFactory ?? createRenderer)(options.canvas);
+
+  camera.position.set(0, 1.6, 5);
+
+  return {
+    scene,
+    camera,
+    renderer,
+    step(dt: number): void {
+      void dt;
+    }
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,36 @@
+import { createApp } from "./app";
+
+const mount = document.querySelector<HTMLElement>("#app");
+
+if (mount === null) {
+  throw new Error("Missing #app mount point");
+}
+
+const app = createApp();
+
+mount.appendChild(app.renderer.domElement);
+
+let lastFrameTime = performance.now();
+
+function resize(): void {
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+
+  app.camera.aspect = width / height;
+  app.camera.updateProjectionMatrix();
+  app.renderer.setSize(width, height);
+}
+
+function animate(frameTime: DOMHighResTimeStamp): void {
+  const dt = (frameTime - lastFrameTime) / 1000;
+  lastFrameTime = frameTime;
+
+  app.step(dt);
+  app.renderer.render(app.scene, app.camera);
+
+  window.requestAnimationFrame(animate);
+}
+
+resize();
+window.addEventListener("resize", resize);
+window.requestAnimationFrame(animate);

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,0 +1,21 @@
+import * as THREE from "three";
+import { describe, expect, it, vi } from "vitest";
+
+import { createApp, type AppRenderer } from "../src/app";
+
+function createTestRenderer(): AppRenderer {
+  return {
+    domElement: document.createElement("canvas"),
+    render: vi.fn(),
+    setSize: vi.fn()
+  };
+}
+
+describe("createApp", () => {
+  it("creates the Three.js bootstrap objects", () => {
+    const app = createApp({ rendererFactory: createTestRenderer });
+
+    expect(app.scene).toBeInstanceOf(THREE.Scene);
+    expect(app.camera).toBeInstanceOf(THREE.PerspectiveCamera);
+  });
+});


### PR DESCRIPTION
## Add Three.js bootstrap (src/main.ts, src/app.ts) and tests/smoke.test.ts

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #46

### Changes
Land the runnable Three.js bootstrap and the first green unit test so subsequent voxel work has a stable host. src/app.ts exports a small createApp() factory that builds and returns a Three.js Scene, PerspectiveCamera, and WebGLRenderer (or a renderer factory accepting a canvas), plus a no-op step(dt: number) function. The scene can be empty — a placeholder for later voxel work. Export a named API (e.g. createApp, App type) so tests can import it without touching the DOM. src/main.ts: imports createApp, mounts the renderer's canvas into #app from index.html, sizes it to window, attaches a resize listener, and starts a requestAnimationFrame loop that calls step(dt). Guard DOM-only code so importing src/app.ts in vitest's jsdom env does not throw. tests/smoke.test.ts: at minimum imports createApp, asserts the returned scene is a THREE.Scene instance and the camera is a PerspectiveCamera. This is the smoke test mentioned in the MVP roadmap. Do NOT pull in anything from src/input/, src/sim/, or src/hud/ — those entry points are owned by other open tasks.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*