### PR TITLE
test: Add Playwright e2e smoke spec asserting hud-root and canvas-host mount points

### DIFF
--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/test';
+
+test('mounts the app shell', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.locator('#app')).toBeAttached();
+  await expect(page.locator('[data-testid="hud-root"]')).toBeVisible();
+  await expect(page.locator('[data-testid="canvas-host"]')).toBeVisible();
+});


### PR DESCRIPTION
## Add Playwright e2e smoke spec asserting hud-root and canvas-host mount points

**Category:** `test` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #68

### Changes
Activate the existing playwright.config.ts by adding tests/e2e/smoke.spec.ts. The spec must (1) navigate to the configured baseURL ('/'), (2) assert that the #app root element is attached to the DOM, and (3) assert that elements with [data-testid="hud-root"] and [data-testid="canvas-host"] are visible. Add @playwright/test as a devDependency in package.json (the config already imports from it). NOTE: src/main.ts is being created by a separate existing task — do NOT modify or recreate it here. If the bootstrap task does not yet expose the required data-testid hooks, this spec will fail at runtime but should still typecheck and lint clean; coordinate via depends_on by waiting until the Three.js bootstrap task has merged before claiming this task. Use pnpm to add the dev dep so pnpm-lock.yaml is updated. Do NOT run `pnpm playwright test` in validation — browser binaries are not installed in CI; typecheck and lint are sufficient gates for the spec file itself.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*