### PR TITLE
feature: Add BlockId constants and block registry in src/sim/blocks.ts

### DIFF
--- a/src/sim/blocks.ts
+++ b/src/sim/blocks.ts
@@ -1,0 +1,87 @@
+export const BlockId = {
+  AIR: 0,
+  GRASS: 1,
+  DIRT: 2,
+  STONE: 3,
+  WOOD: 4,
+  PLANKS: 5,
+  STICK: 6,
+  COAL: 7,
+  TORCH: 8
+} as const;
+
+export type BlockId = (typeof BlockId)[keyof typeof BlockId];
+
+export interface BlockDefinition {
+  readonly id: BlockId;
+  readonly name: string;
+  readonly solid: boolean;
+  readonly mineable: boolean;
+}
+
+export const BLOCK_REGISTRY = {
+  [BlockId.AIR]: {
+    id: BlockId.AIR,
+    name: "Air",
+    solid: false,
+    mineable: false
+  },
+  [BlockId.GRASS]: {
+    id: BlockId.GRASS,
+    name: "Grass",
+    solid: true,
+    mineable: true
+  },
+  [BlockId.DIRT]: {
+    id: BlockId.DIRT,
+    name: "Dirt",
+    solid: true,
+    mineable: true
+  },
+  [BlockId.STONE]: {
+    id: BlockId.STONE,
+    name: "Stone",
+    solid: true,
+    mineable: true
+  },
+  [BlockId.WOOD]: {
+    id: BlockId.WOOD,
+    name: "Wood",
+    solid: true,
+    mineable: true
+  },
+  [BlockId.PLANKS]: {
+    id: BlockId.PLANKS,
+    name: "Planks",
+    solid: true,
+    mineable: true
+  },
+  [BlockId.STICK]: {
+    id: BlockId.STICK,
+    name: "Stick",
+    solid: false,
+    mineable: false
+  },
+  [BlockId.COAL]: {
+    id: BlockId.COAL,
+    name: "Coal",
+    solid: true,
+    mineable: true
+  },
+  [BlockId.TORCH]: {
+    id: BlockId.TORCH,
+    name: "Torch",
+    solid: false,
+    mineable: true
+  }
+} as const satisfies Readonly<Record<BlockId, BlockDefinition>>;
+
+export function getBlockDefinition(id: BlockId): BlockDefinition {
+  const definition = BLOCK_REGISTRY[id];
+
+  if (definition === undefined) {
+    throw new Error(`Unknown block id: ${id}`);
+  }
+
+  return definition;
+}

--- a/tests/sim/blocks.test.ts
+++ b/tests/sim/blocks.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { BLOCK_REGISTRY, BlockId, getBlockDefinition } from "../../src/sim/blocks";
+
+describe("block registry", () => {
+  it("has a registry entry for every block id", () => {
+    const blockIds = Object.values(BlockId);
+
+    expect(Object.keys(BLOCK_REGISTRY)).toHaveLength(blockIds.length);
+
+    for (const id of blockIds) {
+      expect(BLOCK_REGISTRY[id]?.id).toBe(id);
+    }
+  });
+
+  it("defines expected solid and mineable behavior", () => {
+    expect(BLOCK_REGISTRY[BlockId.AIR]).toMatchObject({
+      solid: false,
+      mineable: false
+    });
+    expect(BLOCK_REGISTRY[BlockId.STONE]).toMatchObject({
+      solid: true,
+      mineable: true
+    });
+    expect(BLOCK_REGISTRY[BlockId.TORCH]).toMatchObject({
+      solid: false,
+      mineable: true
+    });
+  });
+
+  it("gets block definitions by id", () => {
+    expect(getBlockDefinition(BlockId.STONE)).toBe(BLOCK_REGISTRY[BlockId.STONE]);
+  });
+
+  it("throws for unknown numeric ids", () => {
+    expect(() => getBlockDefinition(999 as BlockId)).toThrow("Unknown block id: 999");
+  });
+});


### PR DESCRIPTION
## Add BlockId constants and block registry in src/sim/blocks.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #76

### Changes
Create src/sim/blocks.ts exporting numeric BlockId constants (as `const` object or enum) for AIR=0, GRASS, DIRT, STONE, WOOD, PLANKS, STICK, COAL, TORCH, plus a BlockId union type. Export a BLOCK_REGISTRY keyed by BlockId where each entry has at minimum `{ id: BlockId; name: string; solid: boolean; mineable: boolean }`. AIR must be `solid: false, mineable: false`; GRASS/DIRT/STONE/WOOD/PLANKS/COAL must be `solid: true, mineable: true`; TORCH should be `solid: false, mineable: true`; STICK and PLANKS represent inventory items but include them in the registry with sensible defaults (e.g. STICK `solid: false, mineable: false`). Export a `getBlockDefinition(id: BlockId)` helper that returns the registry entry and throws on unknown ids. Add tests in tests/sim/blocks.test.ts that assert: (a) every BlockId has a registry entry, (b) AIR is non-solid, STONE is solid and mineable, TORCH is non-solid but mineable, (c) getBlockDefinition returns the expected entry by id and throws for an unknown numeric id. Keep the file pure — no imports from three, render, or input layers.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*