### PR TITLE
feature: Add deterministic PRNG and seed utilities in src/sim/random.ts

### DIFF
--- a/src/sim/random.ts
+++ b/src/sim/random.ts
@@ -1,0 +1,60 @@
+export interface Rng {
+  // State is public and mutable so save data can snapshot and restore sequences.
+  state: number;
+  next(): number;
+  nextFloat(): number;
+  nextInt(minInclusive: number, maxExclusive: number): number;
+}
+
+const UINT32_RANGE = 0x100000000;
+const MULBERRY32_INCREMENT = 0x6d2b79f5;
+const FNV_OFFSET_BASIS = 0x811c9dc5;
+const FNV_PRIME = 0x01000193;
+
+export function createRng(seed: number): Rng {
+  return {
+    state: seed >>> 0,
+    next(): number {
+      this.state = (this.state + MULBERRY32_INCREMENT) >>> 0;
+
+      let value = this.state;
+      value = Math.imul(value ^ (value >>> 15), value | 1);
+      value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+
+      return (value ^ (value >>> 14)) >>> 0;
+    },
+    nextFloat(): number {
+      return nextFloat(this);
+    },
+    nextInt(minInclusive: number, maxExclusive: number): number {
+      return nextInt(this, minInclusive, maxExclusive);
+    }
+  };
+}
+
+export function nextFloat(rng: Rng): number {
+  return rng.next() / UINT32_RANGE;
+}
+
+export function nextInt(rng: Rng, minInclusive: number, maxExclusive: number): number {
+  if (!Number.isSafeInteger(minInclusive) || !Number.isSafeInteger(maxExclusive)) {
+    throw new RangeError("nextInt bounds must be safe integers");
+  }
+
+  if (maxExclusive <= minInclusive) {
+    throw new RangeError("nextInt maxExclusive must be greater than minInclusive");
+  }
+
+  return minInclusive + Math.floor(nextFloat(rng) * (maxExclusive - minInclusive));
+}
+
+export function hashStringToSeed(s: string): number {
+  let hash = FNV_OFFSET_BASIS;
+
+  for (let index = 0; index < s.length; index += 1) {
+    hash ^= s.charCodeAt(index);
+    hash = Math.imul(hash, FNV_PRIME);
+  }
+
+  return hash >>> 0;
+}

--- a/tests/sim/random.test.ts
+++ b/tests/sim/random.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { createRng, hashStringToSeed, nextFloat, nextInt, type Rng } from '../../src/sim/random';
+
+function take(rng: Rng, count: number): number[] {
+  return Array.from({ length: count }, () => rng.next());
+}
+
+describe('random utilities', () => {
+  it('produces identical sequences for identical seeds', () => {
+    const first = createRng(12345);
+    const second = createRng(12345);
+
+    expect(take(first, 50)).toEqual(take(second, 50));
+  });
+
+  it('diverges quickly for different seeds', () => {
+    const first = take(createRng(12345), 5);
+    const second = take(createRng(54321), 5);
+
+    expect(first).not.toEqual(second);
+  });
+
+  it('keeps nextInt within [min, max)', () => {
+    const rng = createRng(99);
+    const minInclusive = -3;
+    const maxExclusive = 7;
+
+    for (let index = 0; index < 200; index += 1) {
+      const value = nextInt(rng, minInclusive, maxExclusive);
+
+      expect(Number.isInteger(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(minInclusive);
+      expect(value).toBeLessThan(maxExclusive);
+    }
+  });
+
+  it('keeps nextFloat within [0, 1)', () => {
+    const rng = createRng(100);
+
+    for (let index = 0; index < 200; index += 1) {
+      const value = nextFloat(rng);
+
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+
+  it('hashes strings to stable, distinct fixture seeds', () => {
+    const strings = ['', 'world', 'World', 'blockstead', 'seed:42'];
+    const seeds = strings.map((value) => hashStringToSeed(value));
+
+    expect(strings.map((value) => hashStringToSeed(value))).toEqual(seeds);
+    expect(new Set(seeds).size).toBe(strings.length);
+  });
+
+  it('resumes the same sequence after snapshotting and restoring state', () => {
+    const rng = createRng(9001);
+    take(rng, 3);
+
+    const snapshot = rng.state;
+    const expected = take(rng, 5);
+    const restored = createRng(0);
+    restored.state = snapshot;
+
+    expect(take(restored, 5)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Add deterministic PRNG and seed utilities in src/sim/random.ts

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #81

### Changes
Create src/sim/random.ts implementing a small, dependency-free seedable PRNG (mulberry32 is a good fit — single 32-bit state, fast, well-distributed for non-crypto sim use). Export: (1) createRng(seed: number): Rng — returns an object with `next(): number` producing the next uint32, plus convenience methods; (2) nextFloat(rng): number in [0, 1); (3) nextInt(rng, minInclusive, maxExclusive): integer in range; (4) hashStringToSeed(s: string): number — a stable 32-bit hash (e.g. FNV-1a or cyrb53 truncated) so callers can derive seeds from string inputs deterministically. The Rng object should be a plain mutable struct (e.g. { state: number }) so consumers can persist/restore state for save/load determinism — document this with a one-line comment if non-obvious. Add tests/sim/random.test.ts covering: identical seeds produce identical sequences (assert first ~50 outputs match); different seeds diverge within the first few outputs; nextInt respects [min, max) bounds and never returns max; nextFloat stays in [0, 1); hashStringToSeed is stable (same string → same seed across calls) and different strings produce different seeds for a small fixture set; PRNG state can be snapshotted and restored to resume the same sequence. Do NOT wire random.ts into src/sim/index.ts re-exports yet — the sim index.ts is currently a comment-only placeholder and other in-flight tasks (chunk, blocks) will coordinate the barrel export. Just ensure the file is importable by absolute path from tests.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*