### PR TITLE
feature: Add save/load codec in src/sim/save.ts with version validation

### DIFF
--- a/src/sim/save.ts
+++ b/src/sim/save.ts
@@ -1,0 +1,290 @@
+import { BlockId } from "./blocks";
+
+export const SAVE_VERSION = 1;
+
+export interface SaveMutation {
+  x: number;
+  y: number;
+  z: number;
+  block: BlockId;
+}
+
+export interface SaveState {
+  version: number;
+  seed: number;
+  mutations: Array<SaveMutation>;
+  player: {
+    position: [number, number, number];
+    orientation: {
+      yaw: number;
+      pitch: number;
+    };
+  };
+  inventory: {
+    slots: Array<{ block: BlockId; count: number } | null>;
+  };
+  hotbar: {
+    selected: number;
+  };
+}
+
+export type SaveError =
+  | { kind: "invalid_json"; message: string }
+  | { kind: "version_mismatch"; message: string; expected: number; actual: number }
+  | { kind: "invalid_shape"; message: string };
+
+export type DeserializeSaveResult =
+  | { ok: true; state: SaveState }
+  | { ok: false; error: SaveError };
+
+const VALID_BLOCK_IDS = new Set<number>(Object.values(BlockId));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isBlockId(value: unknown): value is BlockId {
+  return typeof value === "number" && Number.isInteger(value) && VALID_BLOCK_IDS.has(value);
+}
+
+function invalidShape(message: string): DeserializeSaveResult {
+  return { ok: false, error: { kind: "invalid_shape", message } };
+}
+
+function readNumber(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key];
+
+  return isFiniteNumber(value) ? value : null;
+}
+
+function readBlockId(record: Record<string, unknown>, key: string): BlockId | null {
+  const value = record[key];
+
+  return isBlockId(value) ? value : null;
+}
+
+function validateMutation(value: unknown): SaveMutation | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const x = readNumber(value, "x");
+  const y = readNumber(value, "y");
+  const z = readNumber(value, "z");
+  const block = readBlockId(value, "block");
+
+  if (x === null || y === null || z === null || block === null) {
+    return null;
+  }
+
+  return { x, y, z, block };
+}
+
+function validateMutations(value: unknown): Array<SaveMutation> | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const mutations: Array<SaveMutation> = [];
+
+  for (const entry of value) {
+    const mutation = validateMutation(entry);
+
+    if (mutation === null) {
+      return null;
+    }
+
+    mutations.push(mutation);
+  }
+
+  return mutations;
+}
+
+function validatePosition(value: unknown): [number, number, number] | null {
+  if (!Array.isArray(value) || value.length !== 3) {
+    return null;
+  }
+
+  const [x, y, z] = value;
+
+  if (!isFiniteNumber(x) || !isFiniteNumber(y) || !isFiniteNumber(z)) {
+    return null;
+  }
+
+  return [x, y, z];
+}
+
+function validatePlayer(value: unknown): SaveState["player"] | null {
+  if (!isRecord(value) || !isRecord(value.orientation)) {
+    return null;
+  }
+
+  const position = validatePosition(value.position);
+  const yaw = readNumber(value.orientation, "yaw");
+  const pitch = readNumber(value.orientation, "pitch");
+
+  if (position === null || yaw === null || pitch === null) {
+    return null;
+  }
+
+  return {
+    position,
+    orientation: { yaw, pitch }
+  };
+}
+
+function validateInventorySlot(value: unknown): SaveState["inventory"]["slots"][number] | null | undefined {
+  if (value === null) {
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const block = readBlockId(value, "block");
+  const count = readNumber(value, "count");
+
+  if (block === null || count === null) {
+    return undefined;
+  }
+
+  return { block, count };
+}
+
+function validateInventory(value: unknown): SaveState["inventory"] | null {
+  if (!isRecord(value) || !Array.isArray(value.slots)) {
+    return null;
+  }
+
+  const slots: SaveState["inventory"]["slots"] = [];
+
+  for (const entry of value.slots) {
+    const slot = validateInventorySlot(entry);
+
+    if (slot === undefined) {
+      return null;
+    }
+
+    slots.push(slot);
+  }
+
+  return { slots };
+}
+
+function validateHotbar(value: unknown): SaveState["hotbar"] | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const selected = readNumber(value, "selected");
+
+  return selected === null ? null : { selected };
+}
+
+export function serializeSave(state: SaveState): string {
+  return JSON.stringify({
+    version: state.version,
+    seed: state.seed,
+    mutations: state.mutations.map((mutation) => ({
+      x: mutation.x,
+      y: mutation.y,
+      z: mutation.z,
+      block: mutation.block
+    })),
+    player: {
+      position: [
+        state.player.position[0],
+        state.player.position[1],
+        state.player.position[2]
+      ],
+      orientation: {
+        yaw: state.player.orientation.yaw,
+        pitch: state.player.orientation.pitch
+      }
+    },
+    inventory: {
+      slots: state.inventory.slots.map((slot) =>
+        slot === null
+          ? null
+          : {
+              block: slot.block,
+              count: slot.count
+            }
+      )
+    },
+    hotbar: {
+      selected: state.hotbar.selected
+    }
+  });
+}
+
+export function deserializeSave(json: string): DeserializeSaveResult {
+  let payload: unknown;
+
+  try {
+    payload = JSON.parse(json);
+  } catch {
+    return {
+      ok: false,
+      error: {
+        kind: "invalid_json",
+        message: "Save data is not valid JSON."
+      }
+    };
+  }
+
+  if (!isRecord(payload)) {
+    return invalidShape("Save data must be a JSON object.");
+  }
+
+  const version = readNumber(payload, "version");
+
+  if (version === null) {
+    return invalidShape("Save data must include a numeric version.");
+  }
+
+  if (version !== SAVE_VERSION) {
+    return {
+      ok: false,
+      error: {
+        kind: "version_mismatch",
+        message: `Unsupported save version ${version}; expected ${SAVE_VERSION}.`,
+        expected: SAVE_VERSION,
+        actual: version
+      }
+    };
+  }
+
+  const seed = readNumber(payload, "seed");
+  const mutations = validateMutations(payload.mutations);
+  const player = validatePlayer(payload.player);
+  const inventory = validateInventory(payload.inventory);
+  const hotbar = validateHotbar(payload.hotbar);
+
+  if (
+    seed === null ||
+    mutations === null ||
+    player === null ||
+    inventory === null ||
+    hotbar === null
+  ) {
+    return invalidShape("Save data does not match the expected save schema.");
+  }
+
+  return {
+    ok: true,
+    state: {
+      version,
+      seed,
+      mutations,
+      player,
+      inventory,
+      hotbar
+    }
+  };
+}

--- a/tests/sim/save.test.ts
+++ b/tests/sim/save.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import {
+  deserializeSave,
+  SAVE_VERSION,
+  serializeSave,
+  type SaveState
+} from "../../src/sim/save";
+
+const baseState: SaveState = {
+  version: SAVE_VERSION,
+  seed: 12345,
+  mutations: [
+    { x: 1, y: 4, z: 2, block: BlockId.DIRT },
+    { x: -3, y: 7, z: 9, block: BlockId.AIR },
+    { x: 32, y: 5, z: -16, block: BlockId.TORCH }
+  ],
+  player: {
+    position: [10.5, 12, -3.25],
+    orientation: {
+      yaw: 1.25,
+      pitch: -0.5
+    }
+  },
+  inventory: {
+    slots: [
+      { block: BlockId.GRASS, count: 12 },
+      null,
+      { block: BlockId.TORCH, count: 3 }
+    ]
+  },
+  hotbar: {
+    selected: 2
+  }
+};
+
+describe("save codec", () => {
+  it("round-trips save state", () => {
+    const result = deserializeSave(serializeSave(baseState));
+
+    expect(result).toEqual({ ok: true, state: baseState });
+  });
+
+  it("rejects unsupported save versions", () => {
+    const payload = {
+      ...baseState,
+      version: SAVE_VERSION + 1
+    };
+    const result = deserializeSave(JSON.stringify(payload));
+
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({
+      ok: false,
+      error: { kind: "version_mismatch" }
+    });
+  });
+
+  it("returns invalid_json for malformed JSON", () => {
+    const result = deserializeSave("{not json");
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { kind: "invalid_json" }
+    });
+  });
+
+  it("returns invalid_shape for missing or wrong-typed fields", () => {
+    expect(deserializeSave(JSON.stringify({ ...baseState, seed: "12345" }))).toMatchObject({
+      ok: false,
+      error: { kind: "invalid_shape" }
+    });
+
+    expect(
+      deserializeSave(
+        JSON.stringify({
+          ...baseState,
+          mutations: [{ x: 1, y: 2, z: 3, block: 999 }]
+        })
+      )
+    ).toMatchObject({
+      ok: false,
+      error: { kind: "invalid_shape" }
+    });
+
+    expect(deserializeSave(JSON.stringify({ version: SAVE_VERSION }))).toMatchObject({
+      ok: false,
+      error: { kind: "invalid_shape" }
+    });
+  });
+
+  it("keeps sparse mutation payloads sparse", () => {
+    const sparseState: SaveState = {
+      ...baseState,
+      seed: 999,
+      mutations: [
+        { x: 0, y: 1, z: 0, block: BlockId.STONE },
+        { x: 16, y: 2, z: -16, block: BlockId.WOOD },
+        { x: 31, y: 3, z: -1, block: BlockId.AIR }
+      ]
+    };
+    const json = serializeSave(sparseState);
+    const parsed = JSON.parse(json) as { mutations: unknown[] };
+
+    expect(json.length).toBeLessThan(600);
+    expect(parsed.mutations).toHaveLength(sparseState.mutations.length);
+  });
+});


### PR DESCRIPTION
## Add save/load codec in src/sim/save.ts with version validation

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #86

### Changes
Create src/sim/save.ts that exports a SaveState type and two pure functions: serializeSave(state: SaveState): string and deserializeSave(json: string): { ok: true; state: SaveState } | { ok: false; error: SaveError }. SaveState shape: { version: number; seed: number; mutations: Array<{ x: number; y: number; z: number; block: BlockId }> (or an equivalent sparse map keyed by 'x,y,z'); player: { position: [number, number, number]; orientation: { yaw: number; pitch: number } }; inventory: { slots: Array<{ block: BlockId; count: number } | null> }; hotbar: { selected: number } }. Use a single explicit JSON schema with a top-level version field (export const SAVE_VERSION = 1). serializeSave produces a JSON string containing only the SaveState fields (no full chunks — only mutated voxels). deserializeSave must NOT throw on bad input: parse JSON in a try/catch, validate that every required field exists with the correct primitive type, that version === SAVE_VERSION, that block ids are members of BlockId, and that mutations is sparse (no entries for unchanged voxels — the codec just writes whatever the caller passes, but the test will assert that callers do not pass full chunks). Return { ok: false, error } with a discriminated SaveError union ('invalid_json' | 'version_mismatch' | 'invalid_shape') including a human-readable message. Add tests/sim/save.test.ts covering: (1) round-trip equality — serialize then deserialize yields a structurally equal SaveState; (2) version mismatch — a payload with version: SAVE_VERSION + 1 returns { ok: false, error: { kind: 'version_mismatch' } }; (3) malformed JSON returns { ok: false, error: { kind: 'invalid_json' } }; (4) missing/wrong-typed fields return { ok: false, error: { kind: 'invalid_shape' } }; (5) sparsity — given a SaveState whose mutations array contains only the handful of actually changed voxels (e.g., 3 entries) for a hypothetical multi-chunk world, the serialized JSON length is bounded and the parsed mutations array length equals the input length (no full-chunk expansion). Import BlockId from src/sim/blocks.ts. Do NOT import Three.js, DOM APIs, or localStorage — the codec must be browser-independent so it runs under Vitest in node.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*