### PR TITLE
feature: Add fixed-size Chunk type with get/set helpers in src/sim/chunk.ts

### DIFF
--- a/src/sim/chunk.ts
+++ b/src/sim/chunk.ts
@@ -1,0 +1,52 @@
+import { BlockId } from "./blocks";
+
+export const CHUNK_SIZE = 16;
+const CHUNK_BLOCK_COUNT = CHUNK_SIZE ** 3;
+
+export interface Chunk {
+  readonly size: number;
+  readonly blocks: Uint8Array;
+}
+
+export function createChunk(): Chunk {
+  return {
+    size: CHUNK_SIZE,
+    blocks: new Uint8Array(CHUNK_BLOCK_COUNT).fill(BlockId.AIR)
+  };
+}
+
+export function chunkIndex(x: number, y: number, z: number): number {
+  return x + z * CHUNK_SIZE + y * CHUNK_SIZE * CHUNK_SIZE;
+}
+
+export function inBounds(x: number, y: number, z: number): boolean {
+  return (
+    Number.isInteger(x) &&
+    Number.isInteger(y) &&
+    Number.isInteger(z) &&
+    x >= 0 &&
+    x < CHUNK_SIZE &&
+    y >= 0 &&
+    y < CHUNK_SIZE &&
+    z >= 0 &&
+    z < CHUNK_SIZE
+  );
+}
+
+export function getBlock(chunk: Chunk, x: number, y: number, z: number): BlockId {
+  assertInBounds(x, y, z);
+
+  return chunk.blocks[chunkIndex(x, y, z)] as BlockId;
+}
+
+export function setBlock(chunk: Chunk, x: number, y: number, z: number, id: BlockId): void {
+  assertInBounds(x, y, z);
+
+  chunk.blocks[chunkIndex(x, y, z)] = id;
+}
+
+function assertInBounds(x: number, y: number, z: number): void {
+  if (!inBounds(x, y, z)) {
+    throw new RangeError(`Chunk coordinates out of bounds: ${x}, ${y}, ${z}`);
+  }
+}

--- a/tests/sim/chunk.test.ts
+++ b/tests/sim/chunk.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import { CHUNK_SIZE, chunkIndex, createChunk, getBlock, setBlock } from "../../src/sim/chunk";
+
+describe("chunk", () => {
+  it("creates fresh chunks filled with air", () => {
+    const chunk = createChunk();
+
+    expect(chunk.size).toBe(CHUNK_SIZE);
+    expect(chunk.blocks).toHaveLength(CHUNK_SIZE ** 3);
+    expect([...chunk.blocks].every((block) => block === BlockId.AIR)).toBe(true);
+  });
+
+  it.each([
+    [0, 0, 0, BlockId.GRASS],
+    [15, 15, 15, BlockId.STONE],
+    [4, 7, 11, BlockId.TORCH]
+  ] as const)("round-trips block ids at %i, %i, %i", (x, y, z, id) => {
+    const chunk = createChunk();
+
+    setBlock(chunk, x, y, z, id);
+
+    expect(getBlock(chunk, x, y, z)).toBe(id);
+  });
+
+  it("sets one coordinate without affecting a neighbor", () => {
+    const chunk = createChunk();
+
+    setBlock(chunk, 3, 4, 5, BlockId.DIRT);
+
+    expect(getBlock(chunk, 3, 4, 5)).toBe(BlockId.DIRT);
+    expect(getBlock(chunk, 4, 4, 5)).toBe(BlockId.AIR);
+  });
+
+  it.each([
+    [-1, 0, 0],
+    [16, 0, 0],
+    [0, -1, 0],
+    [0, 16, 0],
+    [0, 0, -1],
+    [0, 0, 16]
+  ] as const)("throws for out-of-bounds coordinates %i, %i, %i", (x, y, z) => {
+    const chunk = createChunk();
+
+    expect(() => getBlock(chunk, x, y, z)).toThrow(RangeError);
+    expect(() => setBlock(chunk, x, y, z, BlockId.STONE)).toThrow(RangeError);
+  });
+
+  it.each([
+    [1, 2, 3],
+    [15, 15, 15]
+  ] as const)("uses x + z*S + y*S*S layout for %i, %i, %i", (x, y, z) => {
+    expect(chunkIndex(x, y, z)).toBe(x + z * CHUNK_SIZE + y * CHUNK_SIZE * CHUNK_SIZE);
+  });
+});


### PR DESCRIPTION
## Add fixed-size Chunk type with get/set helpers in src/sim/chunk.ts

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #77

### Changes
Create src/sim/chunk.ts exporting a fixed CHUNK_SIZE = 16 constant and a `Chunk` type/interface with `{ readonly size: number; readonly blocks: Uint8Array }` (length CHUNK_SIZE**3, all AIR by default). Export pure helpers: `createChunk(): Chunk` (allocates a fresh Uint8Array filled with AIR), `chunkIndex(x: number, y: number, z: number): number` (returns `x + z*CHUNK_SIZE + y*CHUNK_SIZE*CHUNK_SIZE`), `inBounds(x: number, y: number, z: number): boolean`, `getBlock(chunk: Chunk, x: number, y: number, z: number): BlockId` (throws RangeError if out of bounds), and `setBlock(chunk: Chunk, x: number, y: number, z: number, id: BlockId): void` (throws RangeError if out of bounds). Coordinates are local chunk coordinates 0..15. Add tests in tests/sim/chunk.test.ts that assert: (a) a fresh chunk is all AIR, (b) round-trip set/get for a few coordinates including (0,0,0), (15,15,15), and an interior point returns the same BlockId, (c) setBlock at one coordinate does not affect a neighbor, (d) getBlock and setBlock throw RangeError for out-of-bounds coordinates (e.g. -1, 16), (e) chunkIndex matches the documented x + z*S + y*S*S layout for at least two sample points. Import BlockId / AIR from ./blocks.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*