### PR TITLE
feature: Add Player state model with createPlayer and applyIntent in src/sim/player.ts

### DIFF
--- a/src/sim/player.ts
+++ b/src/sim/player.ts
@@ -1,0 +1,64 @@
+export type Vec3 = [number, number, number];
+
+export interface Player {
+  position: Vec3;
+  velocity: Vec3;
+  yaw: number;
+  pitch: number;
+  selectedHotbarSlot: number;
+}
+
+// Deterministic per-frame input deltas for the simulation layer.
+export interface PlayerIntent {
+  moveX: number;
+  moveZ: number;
+  deltaYaw: number;
+  deltaPitch: number;
+  hotbarDelta: number;
+}
+
+const HOTBAR_SLOT_COUNT = 9;
+const PLAYER_ACCELERATION = 12;
+const MIN_PITCH = -Math.PI / 2;
+const MAX_PITCH = Math.PI / 2;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function wrapHotbarSlot(slot: number): number {
+  const wrapped = Math.trunc(slot) % HOTBAR_SLOT_COUNT;
+
+  return wrapped < 0 ? wrapped + HOTBAR_SLOT_COUNT : wrapped;
+}
+
+export function createPlayer(seed?: number): Player;
+export function createPlayer(): Player {
+  return {
+    position: [0, 0, 0],
+    velocity: [0, 0, 0],
+    yaw: 0,
+    pitch: 0,
+    selectedHotbarSlot: 0
+  };
+}
+
+export function applyIntent(player: Readonly<Player>, intent: Readonly<PlayerIntent>, dt: number): Player {
+  const velocity: Vec3 = [
+    player.velocity[0] + intent.moveX * PLAYER_ACCELERATION * dt,
+    player.velocity[1],
+    player.velocity[2] + intent.moveZ * PLAYER_ACCELERATION * dt
+  ];
+
+  return {
+    position: [
+      player.position[0] + velocity[0] * dt,
+      player.position[1] + velocity[1] * dt,
+      player.position[2] + velocity[2] * dt
+    ],
+    velocity,
+    yaw: player.yaw + intent.deltaYaw,
+    pitch: clamp(player.pitch + intent.deltaPitch, MIN_PITCH, MAX_PITCH),
+    selectedHotbarSlot: wrapHotbarSlot(player.selectedHotbarSlot + intent.hotbarDelta)
+  };
+}

--- a/tests/sim/player.test.ts
+++ b/tests/sim/player.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { applyIntent, createPlayer, type Player, type PlayerIntent } from "../../src/sim/player";
+
+const neutralIntent: PlayerIntent = {
+  moveX: 0,
+  moveZ: 0,
+  deltaYaw: 0,
+  deltaPitch: 0,
+  hotbarDelta: 0
+};
+
+function apply(player: Player, intent: Partial<PlayerIntent>): Player {
+  return applyIntent(player, { ...neutralIntent, ...intent }, 1);
+}
+
+describe("player state", () => {
+  it("creates the documented default state", () => {
+    expect(createPlayer()).toEqual({
+      position: [0, 0, 0],
+      velocity: [0, 0, 0],
+      yaw: 0,
+      pitch: 0,
+      selectedHotbarSlot: 0
+    });
+  });
+
+  it("creates a fresh object on each call", () => {
+    const first = createPlayer();
+    const second = createPlayer();
+
+    expect(first).not.toBe(second);
+    expect(first.position).not.toBe(second.position);
+    expect(first.velocity).not.toBe(second.velocity);
+  });
+
+  it("applies intent without mutating its input", () => {
+    const player: Player = {
+      position: [1, 2, 3],
+      velocity: [0.5, 0, -0.25],
+      yaw: 0.25,
+      pitch: -0.25,
+      selectedHotbarSlot: 4
+    };
+    const snapshot: Player = {
+      position: [...player.position],
+      velocity: [...player.velocity],
+      yaw: player.yaw,
+      pitch: player.pitch,
+      selectedHotbarSlot: player.selectedHotbarSlot
+    };
+    const next = applyIntent(
+      player,
+      {
+        moveX: 1,
+        moveZ: -1,
+        deltaYaw: 0.5,
+        deltaPitch: 0.25,
+        hotbarDelta: 2
+      },
+      0.5
+    );
+
+    expect(next).not.toBe(player);
+    expect(next.position).not.toBe(player.position);
+    expect(next.velocity).not.toBe(player.velocity);
+    expect(player).toEqual(snapshot);
+  });
+
+  it("clamps pitch at positive half pi", () => {
+    const player = { ...createPlayer(), pitch: Math.PI / 2 - 0.01 };
+    const next = apply(player, { deltaPitch: 1 });
+
+    expect(next.pitch).toBe(Math.PI / 2);
+  });
+
+  it("clamps pitch at negative half pi", () => {
+    const player = { ...createPlayer(), pitch: -Math.PI / 2 + 0.01 };
+    const next = apply(player, { deltaPitch: -1 });
+
+    expect(next.pitch).toBe(-Math.PI / 2);
+  });
+
+  it("wraps the selected hotbar slot forward from 8 to 0", () => {
+    const player = { ...createPlayer(), selectedHotbarSlot: 8 };
+    const next = apply(player, { hotbarDelta: 1 });
+
+    expect(next.selectedHotbarSlot).toBe(0);
+  });
+
+  it("wraps the selected hotbar slot backward from 0 to 8", () => {
+    const next = apply(createPlayer(), { hotbarDelta: -1 });
+
+    expect(next.selectedHotbarSlot).toBe(8);
+  });
+
+  it("wraps the selected hotbar slot for larger deltas", () => {
+    const next = apply(createPlayer(), { hotbarDelta: 10 });
+
+    expect(next.selectedHotbarSlot).toBe(1);
+  });
+});


### PR DESCRIPTION
## Add Player state model with createPlayer and applyIntent in src/sim/player.ts

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #99

### Changes
Create src/sim/player.ts exporting a plain Player record type with fields: position (vec3 tuple [number, number, number]), velocity (vec3 tuple), yaw (number, radians), pitch (number, radians), and selectedHotbarSlot (number, integer 0-8). Define a vec3 type alias [number, number, number] (or import from a shared spot if one exists). Export a pure function createPlayer(seed?: number) that returns a deterministic default Player — when seed is provided, you may use createRng(seed) to influence non-essential defaults, but the canonical default state (origin position, zero velocity, yaw=0, pitch=0, selectedHotbarSlot=0) must be returned for an undefined seed. Export a pure function applyIntent(player, intent, dt) that returns a NEW Player with kinematic state updated from a deterministic intent object. The intent shape should be { moveX: number, moveZ: number, deltaYaw: number, deltaPitch: number, hotbarDelta: number } (or similar — pick the shape that fits and document briefly). applyIntent rules: (1) update position by velocity * dt and velocity by some basic acceleration from moveX/moveZ (no collision, no friction beyond simple decay if needed — keep it minimal and deterministic), (2) update yaw by deltaYaw without clamping (yaw wraps freely, but normalize is optional), (3) update pitch by deltaPitch and CLAMP pitch to [-PI/2, +PI/2], (4) update selectedHotbarSlot by hotbarDelta with WRAPAROUND in range [0, 9) — i.e., 9 hotbar slots indexed 0..8. The function must be pure (do not mutate the input player). Add tests/sim/player.test.ts covering: (a) createPlayer() returns the documented default state, (b) createPlayer() returns a fresh object on each call (independent identity), (c) applyIntent does not mutate its input, (d) pitch is clamped at +PI/2 when deltaPitch would push it higher, (e) pitch is clamped at -PI/2 when deltaPitch would push it lower, (f) selectedHotbarSlot wraps from 8 -> 0 when hotbarDelta=+1, (g) selectedHotbarSlot wraps from 0 -> 8 when hotbarDelta=-1, (h) selectedHotbarSlot wraps correctly for larger deltas (e.g. +10 from 0 -> 1). Do NOT add collision detection, input event handling, rendering, or anything that depends on Chunk/World — those belong to other modules. Do NOT re-export Player from src/sim/index.ts in this task unless the existing index.ts already has a pattern for new module re-exports; if it does, add the re-export, otherwise leave src/sim/index.ts alone.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*