### PR TITLE
feature: Add inventory data model with stack/merge/split helpers in src/sim/inventory.ts

### DIFF
--- a/src/sim/inventory.ts
+++ b/src/sim/inventory.ts
@@ -1,0 +1,149 @@
+import { BlockId } from "./blocks";
+
+export const MAX_STACK_SIZE = 64;
+export const HOTBAR_SLOT_COUNT = 9;
+export const SLOT_COUNT = 36;
+
+export interface InventorySlot {
+  readonly id: BlockId;
+  readonly count: number;
+}
+
+export interface Inventory {
+  readonly slots: ReadonlyArray<InventorySlot | null>;
+  readonly selectedHotbarSlot: number;
+}
+
+export interface AddItemResult {
+  readonly inventory: Inventory;
+  readonly remainder: number;
+}
+
+export interface RemoveItemResult {
+  readonly inventory: Inventory;
+  readonly removed: number;
+}
+
+function normalizeCount(count: number): number {
+  return Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+}
+
+function cloneSlots(slots: ReadonlyArray<InventorySlot | null>): Array<InventorySlot | null> {
+  return slots.map((slot) => (slot === null ? null : { id: slot.id, count: slot.count }));
+}
+
+function cloneInventory(inventory: Inventory, slots = cloneSlots(inventory.slots)): Inventory {
+  return {
+    slots,
+    selectedHotbarSlot: inventory.selectedHotbarSlot
+  };
+}
+
+function isValidSlotIndex(inventory: Inventory, index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < inventory.slots.length;
+}
+
+function clampHotbarSlot(hotbarIndex: number, slotCount: number): number {
+  const maxHotbarSlot = Math.max(0, Math.min(HOTBAR_SLOT_COUNT, slotCount) - 1);
+
+  if (!Number.isFinite(hotbarIndex)) {
+    return 0;
+  }
+
+  return Math.min(maxHotbarSlot, Math.max(0, Math.trunc(hotbarIndex)));
+}
+
+export function createInventory(slotCount = SLOT_COUNT): Inventory {
+  const normalizedSlotCount = normalizeCount(slotCount);
+
+  return {
+    slots: Array.from({ length: normalizedSlotCount }, () => null),
+    selectedHotbarSlot: 0
+  };
+}
+
+export function addItem(inventory: Inventory, id: BlockId, count: number): AddItemResult {
+  const slots = cloneSlots(inventory.slots);
+  let remainder = normalizeCount(count);
+
+  for (let index = 0; index < slots.length && remainder > 0; index += 1) {
+    const slot = slots[index];
+
+    if (slot === null || slot.id !== id || slot.count >= MAX_STACK_SIZE) {
+      continue;
+    }
+
+    const added = Math.min(MAX_STACK_SIZE - slot.count, remainder);
+    slots[index] = { id, count: slot.count + added };
+    remainder -= added;
+  }
+
+  for (let index = 0; index < slots.length && remainder > 0; index += 1) {
+    if (slots[index] !== null) {
+      continue;
+    }
+
+    const added = Math.min(MAX_STACK_SIZE, remainder);
+    slots[index] = { id, count: added };
+    remainder -= added;
+  }
+
+  return {
+    inventory: cloneInventory(inventory, slots),
+    remainder
+  };
+}
+
+export function removeItem(inventory: Inventory, id: BlockId, count: number): RemoveItemResult {
+  const slots = cloneSlots(inventory.slots);
+  let remaining = normalizeCount(count);
+  let removed = 0;
+
+  for (let index = 0; index < slots.length && remaining > 0; index += 1) {
+    const slot = slots[index];
+
+    if (slot === null || slot.id !== id) {
+      continue;
+    }
+
+    const removedFromSlot = Math.min(slot.count, remaining);
+    const nextCount = slot.count - removedFromSlot;
+    slots[index] = nextCount > 0 ? { id, count: nextCount } : null;
+    removed += removedFromSlot;
+    remaining -= removedFromSlot;
+  }
+
+  return {
+    inventory: cloneInventory(inventory, slots),
+    removed
+  };
+}
+
+export function moveSlot(inventory: Inventory, fromIndex: number, toIndex: number): Inventory {
+  const slots = cloneSlots(inventory.slots);
+
+  if (!isValidSlotIndex(inventory, fromIndex) || !isValidSlotIndex(inventory, toIndex) || fromIndex === toIndex) {
+    return cloneInventory(inventory, slots);
+  }
+
+  const source = slots[fromIndex];
+  const target = slots[toIndex];
+
+  if (source !== null && target !== null && source.id === target.id && target.count < MAX_STACK_SIZE) {
+    const moved = Math.min(MAX_STACK_SIZE - target.count, source.count);
+    slots[toIndex] = { id: target.id, count: target.count + moved };
+    slots[fromIndex] = source.count === moved ? null : { id: source.id, count: source.count - moved };
+  } else {
+    slots[fromIndex] = target;
+    slots[toIndex] = source;
+  }
+
+  return cloneInventory(inventory, slots);
+}
+
+export function selectHotbarSlot(inventory: Inventory, hotbarIndex: number): Inventory {
+  return {
+    slots: cloneSlots(inventory.slots),
+    selectedHotbarSlot: clampHotbarSlot(hotbarIndex, inventory.slots.length)
+  };
+}

--- a/tests/sim/inventory.test.ts
+++ b/tests/sim/inventory.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import {
+  addItem,
+  createInventory,
+  HOTBAR_SLOT_COUNT,
+  MAX_STACK_SIZE,
+  moveSlot,
+  removeItem,
+  selectHotbarSlot,
+  type Inventory
+} from "../../src/sim/inventory";
+
+function makeInventory(slots: Inventory["slots"], selectedHotbarSlot = 0): Inventory {
+  return { slots, selectedHotbarSlot };
+}
+
+describe("inventory", () => {
+  it("stacks matching items up to max stack size in one slot", () => {
+    const inventory = makeInventory([{ id: BlockId.DIRT, count: 10 }, null]);
+    const result = addItem(inventory, BlockId.DIRT, MAX_STACK_SIZE - 10);
+
+    expect(result.remainder).toBe(0);
+    expect(result.inventory.slots).toEqual([{ id: BlockId.DIRT, count: MAX_STACK_SIZE }, null]);
+  });
+
+  it("overflows added items into the next empty slot", () => {
+    const inventory = makeInventory([{ id: BlockId.DIRT, count: MAX_STACK_SIZE - 1 }, null]);
+    const result = addItem(inventory, BlockId.DIRT, 2);
+
+    expect(result.remainder).toBe(0);
+    expect(result.inventory.slots).toEqual([
+      { id: BlockId.DIRT, count: MAX_STACK_SIZE },
+      { id: BlockId.DIRT, count: 1 }
+    ]);
+  });
+
+  it("returns a remainder when no slots can fit the added item", () => {
+    const inventory = makeInventory([{ id: BlockId.STONE, count: MAX_STACK_SIZE }]);
+    const result = addItem(inventory, BlockId.DIRT, 3);
+
+    expect(result.remainder).toBe(3);
+    expect(result.inventory.slots).toEqual(inventory.slots);
+  });
+
+  it("removes a partial count and leaves the remainder in the slot", () => {
+    const inventory = makeInventory([{ id: BlockId.WOOD, count: 10 }]);
+    const result = removeItem(inventory, BlockId.WOOD, 4);
+
+    expect(result.removed).toBe(4);
+    expect(result.inventory.slots).toEqual([{ id: BlockId.WOOD, count: 6 }]);
+  });
+
+  it("fully drains matching slots to empty", () => {
+    const inventory = makeInventory([{ id: BlockId.WOOD, count: 3 }]);
+    const result = removeItem(inventory, BlockId.WOOD, 10);
+
+    expect(result.removed).toBe(3);
+    expect(result.inventory.slots).toEqual([null]);
+  });
+
+  it("swaps two different item slots", () => {
+    const inventory = makeInventory([
+      { id: BlockId.DIRT, count: 2 },
+      { id: BlockId.STONE, count: 5 }
+    ]);
+    const result = moveSlot(inventory, 0, 1);
+
+    expect(result.slots).toEqual([
+      { id: BlockId.STONE, count: 5 },
+      { id: BlockId.DIRT, count: 2 }
+    ]);
+  });
+
+  it("merges same-id slots without exceeding max stack size", () => {
+    const inventory = makeInventory([
+      { id: BlockId.DIRT, count: MAX_STACK_SIZE - 2 },
+      { id: BlockId.DIRT, count: 5 }
+    ]);
+    const result = moveSlot(inventory, 1, 0);
+
+    expect(result.slots).toEqual([
+      { id: BlockId.DIRT, count: MAX_STACK_SIZE },
+      { id: BlockId.DIRT, count: 3 }
+    ]);
+  });
+
+  it("selects valid hotbar slots and clamps out-of-bounds selections", () => {
+    const inventory = createInventory();
+
+    expect(selectHotbarSlot(inventory, 3).selectedHotbarSlot).toBe(3);
+    expect(selectHotbarSlot(inventory, -1).selectedHotbarSlot).toBe(0);
+    expect(selectHotbarSlot(inventory, HOTBAR_SLOT_COUNT).selectedHotbarSlot).toBe(HOTBAR_SLOT_COUNT - 1);
+  });
+
+  it("does not mutate input inventories or slots", () => {
+    const inventory = makeInventory([
+      { id: BlockId.DIRT, count: 10 },
+      { id: BlockId.DIRT, count: 1 },
+      null
+    ]);
+    const snapshot = {
+      selectedHotbarSlot: inventory.selectedHotbarSlot,
+      slots: inventory.slots.map((slot) => (slot === null ? null : { id: slot.id, count: slot.count }))
+    };
+
+    const results = [
+      addItem(inventory, BlockId.DIRT, 2).inventory,
+      removeItem(inventory, BlockId.DIRT, 2).inventory,
+      moveSlot(inventory, 0, 1),
+      selectHotbarSlot(inventory, 2)
+    ];
+
+    expect(inventory).toEqual(snapshot);
+    for (const result of results) {
+      expect(result).not.toBe(inventory);
+      expect(result.slots).not.toBe(inventory.slots);
+      expect(result.slots[0]).not.toBe(inventory.slots[0]);
+    }
+  });
+});


### PR DESCRIPTION
## Add inventory data model with stack/merge/split helpers in src/sim/inventory.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #90

### Changes
Create src/sim/inventory.ts exporting an Inventory type and pure helpers. Inventory is a fixed slot count (e.g. SLOT_COUNT constant including a hotbar region) where each slot is either null/empty or { id: BlockId; count: number }. Item ids must use the BlockId enum from src/sim/blocks.ts. Define a MAX_STACK_SIZE constant (e.g. 64). Implement and export: createInventory(slotCount?: number): Inventory — returns an Inventory with all empty slots and selectedHotbarSlot=0; addItem(inventory, id, count): { inventory, remainder } — fills existing matching stacks first up to MAX_STACK_SIZE, then overflows into the next empty slots, returning any remainder that did not fit; removeItem(inventory, id, count): { inventory, removed } — decrements counts across slots (any order is fine, but be deterministic), removing slots that hit zero, returning how many were actually removed; moveSlot(inventory, fromIndex, toIndex): Inventory — swaps or merges (merge when same id and target not full, otherwise swap); selectHotbarSlot(inventory, hotbarIndex): Inventory — sets selectedHotbarSlot, clamped/validated against the hotbar range. All helpers MUST be pure: never mutate the input inventory or its slots; return new objects/arrays. Update src/sim/index.ts to uncomment/add `export * from './inventory';`. Add tests/sim/inventory.test.ts covering: stacking up to MAX_STACK_SIZE in a single slot; overflow into the next empty slot when adding more than fits; addItem returning a non-zero remainder when inventory has no room; removeItem with a partial count leaving a slot with the remaining items; removeItem fully draining a slot (slot becomes empty); moveSlot swapping two different items; moveSlot merging same-id stacks respecting MAX_STACK_SIZE; selectHotbarSlot accepting valid indices and rejecting/clamping out-of-bounds indices; verifying input inventory is not mutated by any helper.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*