### PR TITLE
feature: Add World container with chunk coordinate keys in src/sim/world.ts

### DIFF
--- a/src/sim/world.ts
+++ b/src/sim/world.ts
@@ -1,0 +1,67 @@
+import { BlockId } from "./blocks";
+import {
+  CHUNK_SIZE,
+  createChunk,
+  getBlock as getChunkBlock,
+  setBlock as setChunkBlock,
+  type Chunk
+} from "./chunk";
+
+export type ChunkKey = `${number},${number},${number}`;
+
+export type World = Partial<Record<ChunkKey, Chunk>>;
+
+interface ChunkPosition {
+  readonly key: ChunkKey;
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+export function createWorld(): World {
+  return {};
+}
+
+export function getBlock(world: World, x: number, y: number, z: number): BlockId {
+  const position = getChunkPosition(x, y, z);
+  const chunk = world[position.key];
+
+  if (chunk === undefined) {
+    return BlockId.AIR;
+  }
+
+  return getChunkBlock(chunk, position.x, position.y, position.z);
+}
+
+export function setBlock(world: World, x: number, y: number, z: number, blockId: BlockId): void {
+  const position = getChunkPosition(x, y, z);
+  let chunk = world[position.key];
+
+  if (chunk === undefined) {
+    chunk = createChunk();
+    world[position.key] = chunk;
+  }
+
+  setChunkBlock(chunk, position.x, position.y, position.z, blockId);
+}
+
+function getChunkPosition(x: number, y: number, z: number): ChunkPosition {
+  const cx = chunkCoordinate(x);
+  const cy = chunkCoordinate(y);
+  const cz = chunkCoordinate(z);
+
+  return {
+    key: `${cx},${cy},${cz}`,
+    x: localCoordinate(x),
+    y: localCoordinate(y),
+    z: localCoordinate(z)
+  };
+}
+
+function chunkCoordinate(coordinate: number): number {
+  return Math.floor(coordinate / CHUNK_SIZE);
+}
+
+function localCoordinate(coordinate: number): number {
+  return ((coordinate % CHUNK_SIZE) + CHUNK_SIZE) % CHUNK_SIZE;
+}

--- a/tests/sim/world.test.ts
+++ b/tests/sim/world.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import { CHUNK_SIZE, getBlock as getChunkBlock, type Chunk } from "../../src/sim/chunk";
+import {
+  createWorld,
+  getBlock,
+  setBlock,
+  type ChunkKey,
+  type World
+} from "../../src/sim/world";
+
+describe("world", () => {
+  it("translates world coordinates across chunk boundaries", () => {
+    const world = createWorld();
+
+    setBlock(world, -1, 2, 3, BlockId.STONE);
+    setBlock(world, CHUNK_SIZE, 2, 3, BlockId.DIRT);
+    setBlock(world, CHUNK_SIZE - 1, 2, 3, BlockId.GRASS);
+    setBlock(world, -1, -1, -1, BlockId.TORCH);
+
+    expect(getBlock(world, -1, 2, 3)).toBe(BlockId.STONE);
+    expect(getBlock(world, CHUNK_SIZE, 2, 3)).toBe(BlockId.DIRT);
+    expect(getBlock(world, CHUNK_SIZE - 1, 2, 3)).toBe(BlockId.GRASS);
+    expect(getBlock(world, -1, -1, -1)).toBe(BlockId.TORCH);
+
+    expect(getChunkBlock(getExistingChunk(world, "-1,0,0"), CHUNK_SIZE - 1, 2, 3)).toBe(
+      BlockId.STONE
+    );
+    expect(getChunkBlock(getExistingChunk(world, "1,0,0"), 0, 2, 3)).toBe(BlockId.DIRT);
+    expect(getChunkBlock(getExistingChunk(world, "0,0,0"), CHUNK_SIZE - 1, 2, 3)).toBe(
+      BlockId.GRASS
+    );
+    expect(
+      getChunkBlock(
+        getExistingChunk(world, "-1,-1,-1"),
+        CHUNK_SIZE - 1,
+        CHUNK_SIZE - 1,
+        CHUNK_SIZE - 1
+      )
+    ).toBe(BlockId.TORCH);
+  });
+
+  it("returns air for missing chunks without allocating them", () => {
+    const world = createWorld();
+
+    expect(getBlock(world, 0, 0, 0)).toBe(BlockId.AIR);
+    expect(getBlock(world, -1, 0, 0)).toBe(BlockId.AIR);
+    expect(getBlock(world, CHUNK_SIZE, 0, 0)).toBe(BlockId.AIR);
+
+    expect(Object.keys(world)).toHaveLength(0);
+  });
+
+  it("allocates a chunk on first write and returns the written block", () => {
+    const world = createWorld();
+
+    setBlock(world, 1, 2, 3, BlockId.WOOD);
+
+    expect(Object.keys(world)).toEqual(["0,0,0"]);
+    expect(getBlock(world, 1, 2, 3)).toBe(BlockId.WOOD);
+  });
+
+  it("keeps an existing chunk when writing air", () => {
+    const world = createWorld();
+
+    setBlock(world, 1, 2, 3, BlockId.STONE);
+    setBlock(world, 1, 2, 3, BlockId.AIR);
+
+    expect(Object.keys(world)).toEqual(["0,0,0"]);
+    expect(getBlock(world, 1, 2, 3)).toBe(BlockId.AIR);
+  });
+
+  it("stores writes in different chunks as distinct entries", () => {
+    const world = createWorld();
+
+    setBlock(world, 0, 0, 0, BlockId.GRASS);
+    setBlock(world, CHUNK_SIZE, 0, 0, BlockId.DIRT);
+
+    expect(Object.keys(world).sort()).toEqual(["0,0,0", "1,0,0"]);
+    expect(getExistingChunk(world, "0,0,0")).not.toBe(getExistingChunk(world, "1,0,0"));
+  });
+});
+
+function getExistingChunk(world: World, key: ChunkKey): Chunk {
+  const chunk = world[key];
+
+  expect(chunk).toBeDefined();
+
+  if (chunk === undefined) {
+    throw new Error(`Missing chunk ${key}`);
+  }
+
+  return chunk;
+}


### PR DESCRIPTION
## Add World container with chunk coordinate keys in src/sim/world.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #117

### Changes
Create src/sim/world.ts that exports a World type/interface keyed by stringified chunk coordinates 'cx,cy,cz' mapping to Chunk instances from src/sim/chunk.ts. Provide a constructor (e.g., createWorld()) plus getBlock(world, x, y, z) and setBlock(world, x, y, z, blockId) helpers that translate world-space integer coordinates into the owning chunk coordinate and intra-chunk local coordinate, then delegate to the existing Chunk get/set helpers. getBlock must return BlockId.AIR when the chunk does not exist (no allocation). setBlock must lazily allocate a chunk when writing into a missing chunk, then delegate. Write tests/sim/world.test.ts covering: (1) coordinate translation across positive and negative chunk boundaries (e.g., reading/writing at x=-1, x=CHUNK_SIZE, x=CHUNK_SIZE-1 hits the correct chunks and local cells), (2) getBlock on a brand-new world returns AIR for any coordinate without creating chunks, (3) setBlock allocates a chunk on first write and subsequent getBlock returns the written value, (4) writing AIR into an existing chunk does not delete the chunk (idempotent), (5) two writes in different chunks produce two distinct entries in the world map. Do NOT modify src/sim/chunk.ts; consume its existing exports. You MAY add `export * from './world';` to src/sim/index.ts if it remains lint-clean.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*