### PR TITLE
feature: Add intent type definitions in src/input/intents.ts

### DIFF
--- a/src/input/intents.ts
+++ b/src/input/intents.ts
@@ -1,0 +1,112 @@
+export type IntentAxis = -1 | 0 | 1;
+
+export interface MoveIntent {
+  readonly kind: "move";
+  readonly forward: IntentAxis;
+  readonly right: IntentAxis;
+  readonly up: IntentAxis;
+  readonly jump: boolean;
+}
+
+export interface LookIntent {
+  readonly kind: "look";
+  readonly yawDelta: number;
+  readonly pitchDelta: number;
+}
+
+export interface MineIntent {
+  readonly kind: "mine";
+}
+
+export interface PlaceIntent {
+  readonly kind: "place";
+}
+
+export interface SelectHotbarIntent {
+  readonly kind: "selectHotbar";
+  readonly slot: number;
+}
+
+export interface ToggleInventoryIntent {
+  readonly kind: "toggleInventory";
+}
+
+export interface SaveIntent {
+  readonly kind: "save";
+}
+
+export type ActionIntent =
+  | MineIntent
+  | PlaceIntent
+  | SelectHotbarIntent
+  | ToggleInventoryIntent
+  | SaveIntent;
+
+export type Intent = MoveIntent | LookIntent | ActionIntent;
+
+export interface IntentFrame {
+  readonly move: MoveIntent | null;
+  readonly look: LookIntent | null;
+  readonly actions: ReadonlyArray<ActionIntent>;
+}
+
+const EMPTY_ACTIONS: ReadonlyArray<ActionIntent> = Object.freeze([]);
+
+const MINE_INTENT: MineIntent = Object.freeze({ kind: "mine" });
+const PLACE_INTENT: PlaceIntent = Object.freeze({ kind: "place" });
+const TOGGLE_INVENTORY_INTENT: ToggleInventoryIntent = Object.freeze({
+  kind: "toggleInventory"
+});
+const SAVE_INTENT: SaveIntent = Object.freeze({ kind: "save" });
+
+export const EMPTY_INTENT_FRAME: IntentFrame = Object.freeze({
+  move: null,
+  look: null,
+  actions: EMPTY_ACTIONS
+});
+
+export function moveIntent(
+  forward: IntentAxis,
+  right: IntentAxis,
+  up: IntentAxis,
+  jump: boolean
+): MoveIntent {
+  return Object.freeze({
+    kind: "move",
+    forward,
+    right,
+    up,
+    jump
+  } satisfies MoveIntent);
+}
+
+export function lookIntent(yawDelta: number, pitchDelta: number): LookIntent {
+  return Object.freeze({
+    kind: "look",
+    yawDelta,
+    pitchDelta
+  } satisfies LookIntent);
+}
+
+export function mineIntent(): MineIntent {
+  return MINE_INTENT;
+}
+
+export function placeIntent(): PlaceIntent {
+  return PLACE_INTENT;
+}
+
+export function selectHotbarIntent(slot: number): SelectHotbarIntent {
+  return Object.freeze({
+    kind: "selectHotbar",
+    slot
+  } satisfies SelectHotbarIntent);
+}
+
+export function toggleInventoryIntent(): ToggleInventoryIntent {
+  return TOGGLE_INVENTORY_INTENT;
+}
+
+export function saveIntent(): SaveIntent {
+  return SAVE_INTENT;
+}

--- a/tests/input/intents.test.ts
+++ b/tests/input/intents.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EMPTY_INTENT_FRAME,
+  lookIntent,
+  mineIntent,
+  moveIntent,
+  placeIntent,
+  saveIntent,
+  selectHotbarIntent,
+  toggleInventoryIntent,
+  type Intent
+} from "../../src/input/intents";
+
+function describeIntent(intent: Intent): string {
+  switch (intent.kind) {
+    case "move":
+      return `move:${intent.forward},${intent.right},${intent.up},${intent.jump}`;
+    case "look":
+      return `look:${intent.yawDelta},${intent.pitchDelta}`;
+    case "mine":
+      return "mine";
+    case "place":
+      return "place";
+    case "selectHotbar":
+      return `selectHotbar:${intent.slot}`;
+    case "toggleInventory":
+      return "toggleInventory";
+    case "save":
+      return "save";
+  }
+}
+
+describe("input intents", () => {
+  it("constructs movement and look intents", () => {
+    expect(moveIntent(1, -1, 0, true)).toEqual({
+      kind: "move",
+      forward: 1,
+      right: -1,
+      up: 0,
+      jump: true
+    });
+
+    expect(lookIntent(0.25, -0.5)).toEqual({
+      kind: "look",
+      yawDelta: 0.25,
+      pitchDelta: -0.5
+    });
+  });
+
+  it("constructs action intents", () => {
+    expect(mineIntent()).toEqual({ kind: "mine" });
+    expect(placeIntent()).toEqual({ kind: "place" });
+    expect(selectHotbarIntent(4)).toEqual({ kind: "selectHotbar", slot: 4 });
+    expect(toggleInventoryIntent()).toEqual({ kind: "toggleInventory" });
+    expect(saveIntent()).toEqual({ kind: "save" });
+  });
+
+  it("exposes an empty neutral intent frame", () => {
+    expect(EMPTY_INTENT_FRAME).toEqual({
+      move: null,
+      look: null,
+      actions: []
+    });
+  });
+
+  it("narrows intent payloads by kind", () => {
+    expect(describeIntent(moveIntent(1, 0, -1, false))).toBe("move:1,0,-1,false");
+    expect(describeIntent(lookIntent(Math.PI / 2, -Math.PI / 4))).toBe(
+      `look:${Math.PI / 2},${-Math.PI / 4}`
+    );
+    expect(describeIntent(selectHotbarIntent(7))).toBe("selectHotbar:7");
+    expect(describeIntent(saveIntent())).toBe("save");
+  });
+});


### PR DESCRIPTION
## Add intent type definitions in src/input/intents.ts

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #114

### Changes
Create src/input/intents.ts exporting a discriminated-union Intent type with variants: MoveIntent (kind: 'move'; forward, right, up axes as -1|0|1; jump: boolean), LookIntent (kind: 'look'; yawDelta, pitchDelta as numbers in radians), MineIntent (kind: 'mine'), PlaceIntent (kind: 'place'), SelectHotbarIntent (kind: 'selectHotbar'; slot: number), ToggleInventoryIntent (kind: 'toggleInventory'), and SaveIntent (kind: 'save'). Also export an IntentFrame record type that aggregates one frame's worth of intents (e.g. { move: MoveIntent | null, look: LookIntent | null, actions: ReadonlyArray<MineIntent | PlaceIntent | SelectHotbarIntent | ToggleInventoryIntent | SaveIntent> }) plus an EMPTY_INTENT_FRAME constant (or createEmptyIntentFrame() helper) representing a neutral frame with no inputs. Include small constructor helpers (e.g. moveIntent(...), lookIntent(...), selectHotbarIntent(slot), and singletons or factories for the no-payload variants) so tests and downstream consumers don't repeat literal kind strings. Add tests/input/intents.test.ts asserting: (1) each constructor produces an object with the correct kind discriminant and payload shape, (2) the empty IntentFrame has null move, null look, and an empty actions array, (3) a TypeScript type-narrowing check via switch on kind compiles and runs (cover at least move, look, selectHotbar, save). Module must be pure data — no DOM, no Three.js, no imports from src/sim or src/render — so src/sim can later import it without violating the input→sim boundary.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*