### PR TITLE
feature: Add seeded terrain generator in src/sim/terrain.ts

### DIFF
--- a/src/sim/terrain.ts
+++ b/src/sim/terrain.ts
@@ -1,0 +1,93 @@
+import { BlockId } from "./blocks";
+import { CHUNK_SIZE, createChunk, setBlock, type Chunk } from "./chunk";
+import { createRng, hashStringToSeed } from "./random";
+
+const DIRT_DEPTH = 3;
+const BASE_SURFACE_HEIGHT = 8;
+const SURFACE_AMPLITUDE = 3;
+const OCTAVES = [
+  { scale: 32, weight: 4 },
+  { scale: 16, weight: 2 },
+  { scale: 8, weight: 1 }
+] as const;
+const TOTAL_OCTAVE_WEIGHT = 7;
+
+export function generateChunk(
+  seed: number,
+  chunkCoord: { readonly x: number; readonly y: number; readonly z: number }
+): Chunk {
+  const chunk = createChunk();
+  const originX = chunkCoord.x * CHUNK_SIZE;
+  const originY = chunkCoord.y * CHUNK_SIZE;
+  const originZ = chunkCoord.z * CHUNK_SIZE;
+
+  for (let x = 0; x < CHUNK_SIZE; x += 1) {
+    const worldX = originX + x;
+
+    for (let z = 0; z < CHUNK_SIZE; z += 1) {
+      const worldZ = originZ + z;
+      const surfaceY = surfaceHeight(seed, worldX, worldZ);
+
+      for (let y = 0; y < CHUNK_SIZE; y += 1) {
+        const worldY = originY + y;
+
+        setBlock(chunk, x, y, z, blockForHeight(worldY, surfaceY));
+      }
+    }
+  }
+
+  return chunk;
+}
+
+function blockForHeight(worldY: number, surfaceY: number): BlockId {
+  if (worldY > surfaceY) {
+    return BlockId.AIR;
+  }
+
+  if (worldY === surfaceY) {
+    return BlockId.GRASS;
+  }
+
+  if (worldY >= surfaceY - DIRT_DEPTH) {
+    return BlockId.DIRT;
+  }
+
+  return BlockId.STONE;
+}
+
+function surfaceHeight(seed: number, worldX: number, worldZ: number): number {
+  let noise = 0;
+
+  for (const octave of OCTAVES) {
+    noise += valueNoise(seed, worldX, worldZ, octave.scale) * octave.weight;
+  }
+
+  return Math.round(BASE_SURFACE_HEIGHT + (noise / TOTAL_OCTAVE_WEIGHT) * SURFACE_AMPLITUDE);
+}
+
+function valueNoise(seed: number, worldX: number, worldZ: number, scale: number): number {
+  const scaledX = worldX / scale;
+  const scaledZ = worldZ / scale;
+  const cellX = Math.floor(scaledX);
+  const cellZ = Math.floor(scaledZ);
+  const fractionX = scaledX - cellX;
+  const fractionZ = scaledZ - cellZ;
+  const northWest = latticeValue(seed, cellX, cellZ);
+  const northEast = latticeValue(seed, cellX + 1, cellZ);
+  const southWest = latticeValue(seed, cellX, cellZ + 1);
+  const southEast = latticeValue(seed, cellX + 1, cellZ + 1);
+  const north = lerp(northWest, northEast, fractionX);
+  const south = lerp(southWest, southEast, fractionX);
+
+  return lerp(north, south, fractionZ);
+}
+
+function latticeValue(seed: number, cellX: number, cellZ: number): number {
+  const rng = createRng(hashStringToSeed(`terrain:${seed}:${cellX}:${cellZ}`));
+
+  return rng.nextFloat() * 2 - 1;
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}

--- a/tests/sim/terrain.test.ts
+++ b/tests/sim/terrain.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import { CHUNK_SIZE, getBlock, type Chunk } from "../../src/sim/chunk";
+import { generateChunk } from "../../src/sim/terrain";
+
+const DIRT_DEPTH = 3;
+
+describe("terrain generator", () => {
+  it("creates byte-equal chunks for the same seed and coordinate", () => {
+    const chunkCoord = { x: 2, y: 0, z: -3 };
+    const first = generateChunk(12345, chunkCoord);
+    const second = generateChunk(12345, chunkCoord);
+
+    expect(Array.from(first.blocks)).toEqual(Array.from(second.blocks));
+  });
+
+  it("orders air, grass, dirt, and stone within every column", () => {
+    const chunk = generateChunk(2026, { x: 0, y: 0, z: 0 });
+
+    for (let x = 0; x < CHUNK_SIZE; x += 1) {
+      for (let z = 0; z < CHUNK_SIZE; z += 1) {
+        const topY = topSolidY(chunk, x, z);
+
+        expect(getBlock(chunk, x, topY, z)).toBe(BlockId.GRASS);
+
+        for (let y = topY + 1; y < CHUNK_SIZE; y += 1) {
+          expect(getBlock(chunk, x, y, z)).toBe(BlockId.AIR);
+        }
+
+        for (let offset = 1; offset <= DIRT_DEPTH; offset += 1) {
+          expect(getBlock(chunk, x, topY - offset, z)).toBe(BlockId.DIRT);
+        }
+
+        for (let y = 0; y < topY - DIRT_DEPTH; y += 1) {
+          expect(getBlock(chunk, x, y, z)).toBe(BlockId.STONE);
+        }
+      }
+    }
+  });
+
+  it("keeps adjacent chunk boundary columns close in height", () => {
+    const west = generateChunk(77, { x: 0, y: 0, z: 0 });
+    const east = generateChunk(77, { x: 1, y: 0, z: 0 });
+
+    for (let z = 0; z < CHUNK_SIZE; z += 1) {
+      const westHeight = topSolidY(west, CHUNK_SIZE - 1, z);
+      const eastHeight = topSolidY(east, 0, z);
+
+      expect(Math.abs(westHeight - eastHeight)).toBeLessThanOrEqual(2);
+    }
+  });
+});
+
+function topSolidY(chunk: Chunk, x: number, z: number): number {
+  for (let y = CHUNK_SIZE - 1; y >= 0; y -= 1) {
+    if (getBlock(chunk, x, y, z) !== BlockId.AIR) {
+      return y;
+    }
+  }
+
+  throw new Error(`Column has no solid blocks: ${x}, ${z}`);
+}


### PR DESCRIPTION
## Add seeded terrain generator in src/sim/terrain.ts

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #113

### Changes
Create src/sim/terrain.ts exporting generateChunk(seed: number, chunkCoord: { x: number; y: number; z: number }) that returns a Chunk filled with stone below a height threshold, a dirt band above the stone, grass as the topmost solid block, and air above. Derive a per-column surface height by combining the seed with the world (x, z) column coordinates via the Mulberry32 PRNG in src/sim/random.ts (e.g. hash seed + column coords into a sub-seed via createRng / hashStringToSeed, then sample one or more octaves of value noise) so the same (seed, chunkCoord) pair yields byte-equal chunks. Use the Chunk type and its setter helpers from src/sim/chunk.ts (created by the existing queued chunk task — this task should not land until that file exists). Add tests/sim/terrain.test.ts covering: (1) determinism — calling generateChunk twice with identical (seed, chunkCoord) produces chunks whose underlying voxel arrays are byte-equal; (2) layer ordering — for each column, every air voxel sits above any solid voxel, the topmost solid voxel is GRASS, the band immediately below grass is DIRT, and everything below the dirt band is STONE; (3) continuity — surface heights for two horizontally adjacent chunk coordinates differ by at most a small bound (e.g. <=2) at the shared boundary columns, so the world looks continuous.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*