### PR TITLE
feature: Add mouse input adapter emitting look/mine/place intents

### DIFF
--- a/src/input/mouse.ts
+++ b/src/input/mouse.ts
@@ -1,0 +1,102 @@
+import { lookIntent, mineIntent, placeIntent, type Intent } from "./intents";
+
+export interface MouseAdapterEventSource {
+  addEventListener(
+    type: string,
+    listener: EventListener,
+    options?: AddEventListenerOptions | boolean
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListener,
+    options?: EventListenerOptions | boolean
+  ): void;
+}
+
+export type MouseIntentSubscriber = (intent: Intent) => void;
+
+export interface MouseAdapter {
+  subscribe(subscriber: MouseIntentSubscriber): () => void;
+  drain(): Intent[];
+  dispose(): void;
+}
+
+type MouseButtonEvent = Partial<Pick<MouseEvent, "button">>;
+type MouseMoveEvent = Partial<Pick<MouseEvent, "movementX" | "movementY">>;
+type MouseEventName = "mousemove" | "mousedown" | "mouseup";
+
+export function createMouseAdapter(
+  source: MouseAdapterEventSource,
+  subscriber?: MouseIntentSubscriber
+): MouseAdapter {
+  const subscribers = new Set<MouseIntentSubscriber>();
+  const queue: Intent[] = [];
+  let disposed = false;
+
+  if (subscriber !== undefined) {
+    subscribers.add(subscriber);
+  }
+
+  function emit(intent: Intent): void {
+    if (disposed) {
+      return;
+    }
+
+    queue.push(intent);
+    for (const currentSubscriber of subscribers) {
+      currentSubscriber(intent);
+    }
+  }
+
+  const handleMouseMove: EventListener = (event) => {
+    const { movementX = 0, movementY = 0 } = event as MouseMoveEvent;
+    emit(lookIntent(movementX, movementY));
+  };
+
+  const handleButton: EventListener = (event) => {
+    const { button } = event as MouseButtonEvent;
+
+    if (button === 0) {
+      emit(mineIntent());
+    } else if (button === 2) {
+      emit(placeIntent());
+    }
+  };
+
+  const listeners: ReadonlyArray<readonly [MouseEventName, EventListener]> = [
+    ["mousemove", handleMouseMove],
+    ["mousedown", handleButton],
+    ["mouseup", handleButton]
+  ];
+
+  for (const [type, listener] of listeners) {
+    source.addEventListener(type, listener);
+  }
+
+  return {
+    subscribe(nextSubscriber: MouseIntentSubscriber): () => void {
+      if (disposed) {
+        return () => undefined;
+      }
+
+      subscribers.add(nextSubscriber);
+      return () => {
+        subscribers.delete(nextSubscriber);
+      };
+    },
+    drain(): Intent[] {
+      return queue.splice(0, queue.length);
+    },
+    dispose(): void {
+      if (disposed) {
+        return;
+      }
+
+      disposed = true;
+      for (const [type, listener] of listeners) {
+        source.removeEventListener(type, listener);
+      }
+      subscribers.clear();
+    }
+  };
+}

--- a/tests/input/mouse.test.ts
+++ b/tests/input/mouse.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createMouseAdapter,
+  type MouseAdapterEventSource
+} from "../../src/input/mouse";
+import {
+  lookIntent,
+  mineIntent,
+  placeIntent,
+  type Intent
+} from "../../src/input/intents";
+
+class FakeMouseEventSource implements MouseAdapterEventSource {
+  private readonly listeners = new Map<string, Set<EventListener>>();
+
+  addEventListener(type: string, listener: EventListener): void {
+    const listenersForType = this.listeners.get(type) ?? new Set<EventListener>();
+    listenersForType.add(listener);
+    this.listeners.set(type, listenersForType);
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: string, event: Event): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+function syntheticMouseEvent(
+  type: string,
+  init: Partial<Pick<MouseEvent, "button" | "movementX" | "movementY">>
+): Event {
+  const event = new Event(type);
+
+  if (init.button !== undefined) {
+    Object.defineProperty(event, "button", { value: init.button });
+  }
+  if (init.movementX !== undefined) {
+    Object.defineProperty(event, "movementX", { value: init.movementX });
+  }
+  if (init.movementY !== undefined) {
+    Object.defineProperty(event, "movementY", { value: init.movementY });
+  }
+
+  return event;
+}
+
+describe("mouse input adapter", () => {
+  it("emits look intents from movement deltas", () => {
+    const source = new FakeMouseEventSource();
+    const emitted: Intent[] = [];
+    createMouseAdapter(source, (intent) => {
+      emitted.push(intent);
+    });
+
+    source.emit(
+      "mousemove",
+      syntheticMouseEvent("mousemove", { movementX: 4, movementY: -3 })
+    );
+
+    expect(emitted).toEqual([lookIntent(4, -3)]);
+  });
+
+  it("emits mine and place intents from mouse buttons", () => {
+    const source = new FakeMouseEventSource();
+    const emitted: Intent[] = [];
+    createMouseAdapter(source, (intent) => {
+      emitted.push(intent);
+    });
+
+    source.emit("mousedown", syntheticMouseEvent("mousedown", { button: 0 }));
+    source.emit("mouseup", syntheticMouseEvent("mouseup", { button: 2 }));
+
+    expect(emitted).toEqual([mineIntent(), placeIntent()]);
+  });
+
+  it("supports pulling queued intents", () => {
+    const source = new FakeMouseEventSource();
+    const adapter = createMouseAdapter(source);
+
+    source.emit(
+      "mousemove",
+      syntheticMouseEvent("mousemove", { movementX: -2, movementY: 5 })
+    );
+    source.emit("mousedown", syntheticMouseEvent("mousedown", { button: 0 }));
+
+    expect(adapter.drain()).toEqual([lookIntent(-2, 5), mineIntent()]);
+    expect(adapter.drain()).toEqual([]);
+  });
+
+  it("removes listeners when disposed", () => {
+    const source = new FakeMouseEventSource();
+    const emitted: Intent[] = [];
+    const adapter = createMouseAdapter(source, (intent) => {
+      emitted.push(intent);
+    });
+
+    adapter.dispose();
+    source.emit(
+      "mousemove",
+      syntheticMouseEvent("mousemove", { movementX: 1, movementY: 1 })
+    );
+    source.emit("mousedown", syntheticMouseEvent("mousedown", { button: 0 }));
+
+    expect(emitted).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Add mouse input adapter emitting look/mine/place intents

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #123

### Changes
Implement src/input/mouse.ts: export a createMouseAdapter (or similarly named) factory that accepts a thin injectable event-source seam (object exposing addEventListener/removeEventListener like window/document, or an EventTarget) and emits Intent objects from src/input/intents.ts. Subscribe to mousemove (using movementX/movementY for look-delta intents), mousedown/mouseup (left button -> mine intent, right button -> place intent), and optional wheel for hotbar scroll if the Intent union supports it. Provide a subscriber callback or pull-queue API plus a dispose/teardown that removes all listeners. Write tests/input/mouse.test.ts driving synthetic MouseEvent-shaped objects through a fake event source: assert look-delta intents from movementX/movementY, mine intent on left button, place intent on right button, and that dispose stops emissions. Do NOT import from src/sim or src/render.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*