### PR TITLE
feature: Add createScene factory in src/render/scene.ts

### DIFF
--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,0 +1,33 @@
+import * as THREE from "three";
+
+export const DEFAULT_FOG_COLOR = 0x9ec7e8;
+export const DEFAULT_FOG_NEAR = 24;
+export const DEFAULT_FOG_FAR = 128;
+export const DEFAULT_AMBIENT_LIGHT_INTENSITY = 0.75;
+export const DEFAULT_SUN_LIGHT_INTENSITY = 1.2;
+
+export function createScene(): THREE.Scene {
+  const scene = new THREE.Scene();
+
+  scene.background = new THREE.Color(DEFAULT_FOG_COLOR);
+  scene.fog = new THREE.Fog(
+    DEFAULT_FOG_COLOR,
+    DEFAULT_FOG_NEAR,
+    DEFAULT_FOG_FAR
+  );
+
+  const ambientLight = new THREE.HemisphereLight(
+    0xeaf6ff,
+    0x52624a,
+    DEFAULT_AMBIENT_LIGHT_INTENSITY
+  );
+  const sunLight = new THREE.DirectionalLight(
+    0xffffff,
+    DEFAULT_SUN_LIGHT_INTENSITY
+  );
+
+  sunLight.position.set(32, 48, 24);
+  scene.add(ambientLight, sunLight);
+
+  return scene;
+}

--- a/tests/render/scene.test.ts
+++ b/tests/render/scene.test.ts
@@ -1,0 +1,72 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+
+import {
+  createScene,
+  DEFAULT_AMBIENT_LIGHT_INTENSITY,
+  DEFAULT_FOG_COLOR,
+  DEFAULT_FOG_FAR,
+  DEFAULT_FOG_NEAR,
+  DEFAULT_SUN_LIGHT_INTENSITY
+} from "../../src/render/scene";
+
+function getLights(scene: THREE.Scene): THREE.Light[] {
+  return scene.children.filter(
+    (child): child is THREE.Light => child instanceof THREE.Light
+  );
+}
+
+describe("createScene", () => {
+  it("returns a Three.js scene", () => {
+    expect(createScene()).toBeInstanceOf(THREE.Scene);
+  });
+
+  it("adds default presentation lights", () => {
+    const lights = getLights(createScene());
+    const ambientLight = lights.find(
+      (light): light is THREE.HemisphereLight =>
+        light instanceof THREE.HemisphereLight
+    );
+    const sunLight = lights.find(
+      (light): light is THREE.DirectionalLight =>
+        light instanceof THREE.DirectionalLight
+    );
+
+    expect(lights.length).toBeGreaterThanOrEqual(1);
+    expect(ambientLight?.intensity).toBe(DEFAULT_AMBIENT_LIGHT_INTENSITY);
+    expect(sunLight?.intensity).toBe(DEFAULT_SUN_LIGHT_INTENSITY);
+  });
+
+  it("sets the default voxel fog", () => {
+    const fog = createScene().fog;
+
+    expect(fog).toBeInstanceOf(THREE.Fog);
+    if (!(fog instanceof THREE.Fog)) {
+      throw new Error("Expected scene fog to be THREE.Fog");
+    }
+
+    expect(fog.color.getHex()).toBe(DEFAULT_FOG_COLOR);
+    expect(fog.near).toBe(DEFAULT_FOG_NEAR);
+    expect(fog.far).toBe(DEFAULT_FOG_FAR);
+  });
+
+  it("creates independent scene instances", () => {
+    const first = createScene();
+    const second = createScene();
+    const secondChildCount = second.children.length;
+
+    expect(first).not.toBe(second);
+    expect(first.fog).not.toBe(second.fog);
+    expect(getLights(first)[0]).not.toBe(getLights(second)[0]);
+
+    first.add(new THREE.Object3D());
+    expect(second.children).toHaveLength(secondChildCount);
+
+    if (!(first.fog instanceof THREE.Fog) || !(second.fog instanceof THREE.Fog)) {
+      throw new Error("Expected scene fog to be THREE.Fog");
+    }
+
+    first.fog.color.setHex(0x000000);
+    expect(second.fog.color.getHex()).toBe(DEFAULT_FOG_COLOR);
+  });
+});


### PR DESCRIPTION
## Add createScene factory in src/render/scene.ts

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #136

### Changes
Create src/render/scene.ts exporting createScene(): THREE.Scene that constructs a new THREE.Scene with sensible defaults: an ambient/hemisphere light plus a directional sun light, and a THREE.Fog (or FogExp2) configured to match the voxel world look. Expose constants for the default fog color/near/far and light intensities so tests can assert them. The factory should NOT own any simulation state — pure presentation. Add tests/render/scene.test.ts that asserts: (1) the returned object is a THREE.Scene; (2) it contains at least one Light child; (3) scene.fog is set with expected color/near/far defaults; (4) the helper produces independent Scene instances on repeated calls (no shared mutable state).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*