### PR TITLE
feature: Add ItemId registry for non-block craftables in src/sim/items.ts

### DIFF
--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -1,0 +1,59 @@
+import { BlockId } from "./blocks";
+
+export const ItemId = {
+  WOOD_LOG: 100,
+  PLANKS: 101,
+  STICK: 102,
+  COAL: 103,
+  TORCH: 104
+} as const;
+
+export type ItemId = (typeof ItemId)[keyof typeof ItemId];
+
+export interface ItemDef {
+  readonly id: ItemId;
+  readonly name: string;
+  readonly stackSize: number;
+  readonly placesBlockId?: BlockId;
+}
+
+export const ITEM_REGISTRY = {
+  [ItemId.WOOD_LOG]: {
+    id: ItemId.WOOD_LOG,
+    name: "Wood Log",
+    stackSize: 64,
+    placesBlockId: BlockId.WOOD
+  },
+  [ItemId.PLANKS]: {
+    id: ItemId.PLANKS,
+    name: "Planks",
+    stackSize: 64,
+    placesBlockId: BlockId.PLANKS
+  },
+  [ItemId.STICK]: {
+    id: ItemId.STICK,
+    name: "Stick",
+    stackSize: 64
+  },
+  [ItemId.COAL]: {
+    id: ItemId.COAL,
+    name: "Coal",
+    stackSize: 64
+  },
+  [ItemId.TORCH]: {
+    id: ItemId.TORCH,
+    name: "Torch",
+    stackSize: 64,
+    placesBlockId: BlockId.TORCH
+  }
+} as const satisfies Readonly<Record<ItemId, ItemDef>>;
+
+export function getItemDefinition(id: ItemId): ItemDef {
+  const definition = ITEM_REGISTRY[id];
+
+  if (definition === undefined) {
+    throw new Error(`Unknown item id: ${id}`);
+  }
+
+  return definition;
+}

--- a/tests/sim/items.test.ts
+++ b/tests/sim/items.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId, getBlockDefinition } from "../../src/sim/blocks";
+import { ITEM_REGISTRY, ItemId, getItemDefinition, type ItemDef } from "../../src/sim/items";
+
+describe("item registry", () => {
+  it("has a registry entry for every item id", () => {
+    const itemIds = Object.values(ItemId);
+
+    expect(Object.keys(ITEM_REGISTRY)).toHaveLength(itemIds.length);
+
+    for (const id of itemIds) {
+      expect(ITEM_REGISTRY[id]?.id).toBe(id);
+    }
+  });
+
+  it("keeps item ids disjoint from block ids", () => {
+    const blockIds = new Set<number>(Object.values(BlockId));
+
+    for (const id of Object.values(ItemId)) {
+      expect(blockIds.has(id)).toBe(false);
+    }
+  });
+
+  it("only references valid placeable block ids", () => {
+    const items: ReadonlyArray<ItemDef> = Object.values(ITEM_REGISTRY);
+
+    for (const item of items) {
+      if (item.placesBlockId !== undefined) {
+        expect(getBlockDefinition(item.placesBlockId).id).toBe(item.placesBlockId);
+      }
+    }
+  });
+
+  it("gets item definitions by id", () => {
+    expect(getItemDefinition(ItemId.WOOD_LOG)).toBe(ITEM_REGISTRY[ItemId.WOOD_LOG]);
+  });
+
+  it("throws for unknown numeric ids", () => {
+    expect(() => getItemDefinition(999 as ItemId)).toThrow("Unknown item id: 999");
+  });
+
+  it("defines positive integer stack sizes", () => {
+    for (const item of Object.values(ITEM_REGISTRY)) {
+      expect(Number.isInteger(item.stackSize)).toBe(true);
+      expect(item.stackSize).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Add ItemId registry for non-block craftables in src/sim/items.ts

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #101

### Changes
Create src/sim/items.ts exporting an ItemId const object (e.g. WOOD_LOG, PLANKS, STICK, COAL, TORCH) and an ItemId type derived from it. Export an ItemDef interface with at minimum: id (ItemId), name (string), stackSize (number), and optional placesBlockId (BlockId) for items that place blocks (PLANKS and TORCH map to BlockId.PLANKS and BlockId.TORCH; WOOD_LOG maps to BlockId.WOOD; COAL and STICK have no placesBlockId). Export an ITEM_REGISTRY record keyed by ItemId and a getItemDefinition(id: ItemId) helper that throws on unknown ids (mirroring getBlockDefinition style). Choose distinct numeric ItemId values that do NOT collide with existing BlockId numeric values (e.g., start ItemIds at 100) so item ids and block ids cannot be confused if mixed. Add tests/sim/items.test.ts that asserts: (1) every ItemId has a registry entry whose id matches the key; (2) ItemId numeric values are disjoint from BlockId numeric values; (3) every placesBlockId resolves to a valid BlockId via getBlockDefinition; (4) getItemDefinition returns the registry entry for known ids and throws 'Unknown item id: <n>' for unknown ids; (5) stackSize is a positive integer for every item. Do NOT modify src/sim/crafting.ts, src/sim/blocks.ts, or src/sim/index.ts — this task only introduces the new module and its tests.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*