### PR TITLE
feature: Add AABB-vs-voxel swept collision resolver in src/sim/collision.ts

### DIFF
--- a/src/sim/collision.ts
+++ b/src/sim/collision.ts
@@ -1,0 +1,202 @@
+import { BLOCK_REGISTRY, type BlockId } from "./blocks";
+
+export type Vec3 = readonly [number, number, number];
+
+export interface AABB {
+  readonly min: Vec3;
+  readonly max: Vec3;
+}
+
+export interface CollisionContacts {
+  readonly x: boolean;
+  readonly y: boolean;
+  readonly z: boolean;
+}
+
+export interface CollisionResult {
+  readonly delta: Vec3;
+  readonly contacts: CollisionContacts;
+  readonly grounded: boolean;
+}
+
+export type BlockGetter = (x: number, y: number, z: number) => BlockId;
+
+type Axis = 0 | 1 | 2;
+type MutableVec3 = [number, number, number];
+
+interface SweepResult {
+  readonly movement: number;
+  readonly contact: boolean;
+}
+
+const SWEEP_AXES: readonly Axis[] = [0, 2, 1];
+const COLLISION_EPSILON = 0.0001;
+const CELL_EPSILON = 1e-9;
+
+export function resolveCollision(
+  aabb: Readonly<AABB>,
+  delta: Vec3,
+  getBlock: BlockGetter
+): CollisionResult {
+  const min: MutableVec3 = [...aabb.min];
+  const max: MutableVec3 = [...aabb.max];
+  const resolved: MutableVec3 = [0, 0, 0];
+  const contacts = { x: false, y: false, z: false };
+
+  for (const axis of SWEEP_AXES) {
+    const sweep = sweepAxis(min, max, axis, delta[axis], getBlock);
+
+    resolved[axis] = sweep.movement;
+
+    if (sweep.contact) {
+      setContact(contacts, axis);
+    }
+
+    min[axis] += sweep.movement;
+    max[axis] += sweep.movement;
+  }
+
+  return {
+    delta: resolved,
+    contacts,
+    grounded: contacts.y && delta[1] < 0
+  };
+}
+
+function sweepAxis(
+  min: Readonly<MutableVec3>,
+  max: Readonly<MutableVec3>,
+  axis: Axis,
+  desired: number,
+  getBlock: BlockGetter
+): SweepResult {
+  if (desired === 0) {
+    return { movement: 0, contact: false };
+  }
+
+  return desired > 0
+    ? sweepPositive(min, max, axis, desired, getBlock)
+    : sweepNegative(min, max, axis, desired, getBlock);
+}
+
+function sweepPositive(
+  min: Readonly<MutableVec3>,
+  max: Readonly<MutableVec3>,
+  axis: Axis,
+  desired: number,
+  getBlock: BlockGetter
+): SweepResult {
+  const ranges = getRanges(min, max);
+  ranges[axis] = {
+    min: Math.floor(max[axis]),
+    max: Math.floor(max[axis] + desired - CELL_EPSILON)
+  };
+
+  let movement = desired;
+  let contact = false;
+
+  forEachCell(ranges, (x, y, z) => {
+    if (!isSolid(getBlock, x, y, z)) {
+      return;
+    }
+
+    const blockMin = getAxisValue(axis, x, y, z);
+    const candidate = Math.max(0, blockMin - max[axis] - COLLISION_EPSILON);
+
+    if (candidate < movement) {
+      movement = candidate;
+      contact = true;
+    }
+  });
+
+  return { movement, contact };
+}
+
+function sweepNegative(
+  min: Readonly<MutableVec3>,
+  max: Readonly<MutableVec3>,
+  axis: Axis,
+  desired: number,
+  getBlock: BlockGetter
+): SweepResult {
+  const ranges = getRanges(min, max);
+  ranges[axis] = {
+    min: Math.floor(min[axis] + desired),
+    max: Math.floor(min[axis] - CELL_EPSILON)
+  };
+
+  let movement = desired;
+  let contact = false;
+
+  forEachCell(ranges, (x, y, z) => {
+    if (!isSolid(getBlock, x, y, z)) {
+      return;
+    }
+
+    const blockMax = getAxisValue(axis, x, y, z) + 1;
+    const candidate = Math.min(0, blockMax - min[axis] + COLLISION_EPSILON);
+
+    if (candidate > movement) {
+      movement = candidate;
+      contact = true;
+    }
+  });
+
+  return { movement, contact };
+}
+
+function isSolid(getBlock: BlockGetter, x: number, y: number, z: number): boolean {
+  return BLOCK_REGISTRY[getBlock(x, y, z)].solid;
+}
+
+function setContact(contacts: { x: boolean; y: boolean; z: boolean }, axis: Axis): void {
+  if (axis === 0) {
+    contacts.x = true;
+  } else if (axis === 1) {
+    contacts.y = true;
+  } else {
+    contacts.z = true;
+  }
+}
+
+function getAxisValue(axis: Axis, x: number, y: number, z: number): number {
+  if (axis === 0) {
+    return x;
+  }
+
+  if (axis === 1) {
+    return y;
+  }
+
+  return z;
+}
+
+function getRanges(
+  min: Readonly<MutableVec3>,
+  max: Readonly<MutableVec3>
+): MutableVec3Range {
+  return [
+    { min: Math.floor(min[0] + CELL_EPSILON), max: Math.floor(max[0] - CELL_EPSILON) },
+    { min: Math.floor(min[1] + CELL_EPSILON), max: Math.floor(max[1] - CELL_EPSILON) },
+    { min: Math.floor(min[2] + CELL_EPSILON), max: Math.floor(max[2] - CELL_EPSILON) }
+  ];
+}
+
+interface CellRange {
+  min: number;
+  max: number;
+}
+
+type MutableVec3Range = [CellRange, CellRange, CellRange];
+
+function forEachCell(ranges: Readonly<MutableVec3Range>, visit: BlockGetterVisit): void {
+  for (let x = ranges[0].min; x <= ranges[0].max; x += 1) {
+    for (let y = ranges[1].min; y <= ranges[1].max; y += 1) {
+      for (let z = ranges[2].min; z <= ranges[2].max; z += 1) {
+        visit(x, y, z);
+      }
+    }
+  }
+}
+
+type BlockGetterVisit = (x: number, y: number, z: number) => void;

--- a/tests/sim/collision.test.ts
+++ b/tests/sim/collision.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import {
+  resolveCollision,
+  type AABB,
+  type BlockGetter,
+  type CollisionContacts,
+  type Vec3
+} from "../../src/sim/collision";
+
+const EPSILON = 0.0001;
+const BODY: AABB = {
+  min: [0.2, 1.1, 0.2],
+  max: [0.8, 1.9, 0.8]
+};
+
+describe("resolveCollision", () => {
+  it("leaves free movement through air unchanged", () => {
+    const result = resolveCollision(BODY, [1, -0.25, 0.5], air);
+
+    expect(result.delta).toEqual([1, -0.25, 0.5]);
+    expectContacts(result.contacts, {});
+    expect(result.grounded).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "+X",
+      block: [1, 1, 0] as Vec3,
+      delta: [1, 0, 0] as Vec3,
+      expected: 0.2 - EPSILON,
+      axis: 0
+    },
+    {
+      name: "-X",
+      block: [-1, 1, 0] as Vec3,
+      delta: [-1, 0, 0] as Vec3,
+      expected: -0.2 + EPSILON,
+      axis: 0
+    },
+    {
+      name: "+Z",
+      block: [0, 1, 1] as Vec3,
+      delta: [0, 0, 1] as Vec3,
+      expected: 0.2 - EPSILON,
+      axis: 2
+    },
+    {
+      name: "-Z",
+      block: [0, 1, -1] as Vec3,
+      delta: [0, 0, -1] as Vec3,
+      expected: -0.2 + EPSILON,
+      axis: 2
+    }
+  ])("clamps horizontal motion into a $name wall", ({ block, delta, expected, axis }) => {
+    const result = resolveCollision(BODY, delta, blocks([block]));
+
+    expect(result.delta[axis]).toBeCloseTo(expected);
+    expect(result.delta[1]).toBe(0);
+    expectContacts(result.contacts, { [axis === 0 ? "x" : "z"]: true });
+    expect(result.grounded).toBe(false);
+  });
+
+  it("clamps downward motion onto a floor and reports grounded", () => {
+    const body: AABB = {
+      min: [0.2, 1.2, 0.2],
+      max: [0.8, 2.8, 0.8]
+    };
+    const result = resolveCollision(body, [0, -1, 0], blocks([[0, 0, 0]]));
+
+    expect(result.delta).toEqual([0, expect.closeTo(-0.2 + EPSILON), 0]);
+    expectContacts(result.contacts, { y: true });
+    expect(result.grounded).toBe(true);
+  });
+
+  it("clamps upward motion into a ceiling", () => {
+    const body: AABB = {
+      min: [0.2, 1.2, 0.2],
+      max: [0.8, 2.8, 0.8]
+    };
+    const result = resolveCollision(body, [0, 1, 0], blocks([[0, 3, 0]]));
+
+    expect(result.delta).toEqual([0, expect.closeTo(0.2 - EPSILON), 0]);
+    expectContacts(result.contacts, { y: true });
+    expect(result.grounded).toBe(false);
+  });
+
+  it("slides along the clear axis when diagonal motion clips a corner", () => {
+    const result = resolveCollision(BODY, [1, 0, 0.5], blocks([[1, 1, 0]]));
+
+    expect(result.delta[0]).toBeCloseTo(0.2 - EPSILON);
+    expect(result.delta[2]).toBe(0.5);
+    expectContacts(result.contacts, { x: true });
+  });
+
+  it("blocks horizontal step movement while allowing a separate vertical landing", () => {
+    const standing: AABB = {
+      min: [0.2, 1 + EPSILON, 0.2],
+      max: [0.8, 2.8, 0.8]
+    };
+    const stepBlocks = blocks([[1, 1, 0]]);
+    const horizontal = resolveCollision(standing, [1, 0, 0], stepBlocks);
+
+    expect(horizontal.delta[0]).toBeCloseTo(0.2 - EPSILON);
+    expectContacts(horizontal.contacts, { x: true });
+
+    const aboveStep: AABB = {
+      min: [1.2, 2.4, 0.2],
+      max: [1.8, 4.2, 0.8]
+    };
+    const vertical = resolveCollision(aboveStep, [0, -1, 0], stepBlocks);
+
+    expect(vertical.delta[1]).toBeCloseTo(-0.4 + EPSILON);
+    expectContacts(vertical.contacts, { y: true });
+    expect(vertical.grounded).toBe(true);
+  });
+});
+
+function air(): BlockId {
+  return BlockId.AIR;
+}
+
+function blocks(cells: readonly Vec3[]): BlockGetter {
+  const solidCells = new Map(cells.map((cell) => [key(cell[0], cell[1], cell[2]), BlockId.STONE]));
+
+  return (x: number, y: number, z: number) => solidCells.get(key(x, y, z)) ?? BlockId.AIR;
+}
+
+function key(x: number, y: number, z: number): string {
+  return `${x},${y},${z}`;
+}
+
+function expectContacts(contacts: CollisionContacts, expected: Partial<CollisionContacts>): void {
+  expect(contacts).toEqual({
+    x: expected.x ?? false,
+    y: expected.y ?? false,
+    z: expected.z ?? false
+  });
+}


### PR DESCRIPTION
## Add AABB-vs-voxel swept collision resolver in src/sim/collision.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #105

### Changes
Create src/sim/collision.ts exporting an AABB type (e.g. { min: [x,y,z], max: [x,y,z] } or { position, size }), a CollisionResult type with the clamped delta and per-axis contact flags ({ x: boolean, y: boolean, z: boolean } and a `grounded` convenience for -y contact), and a pure function `resolveCollision(aabb, delta, getBlock)` where getBlock is `(x: number, y: number, z: number) => BlockId`. Implementation should sweep the three axes independently (X, then Z, then Y, or another deterministic order) and clamp movement so the AABB stops just before any voxel where `BLOCK_REGISTRY[id].solid === true`. Use a small epsilon (e.g. 1e-4) to avoid wedging into faces. Iterate over the integer voxel cells the AABB overlaps after each tentative axis move and shrink the delta on that axis if any solid block is hit, recording the contact flag. Add tests/sim/collision.test.ts covering: (1) free movement through air leaves delta unchanged and no contact flags set; (2) horizontal motion into a wall on +X stops with x contact flag and clamped dx; same for -X, +Z, -Z; (3) downward motion onto a floor sets grounded/y-contact and clamps dy so the AABB rests on top; (4) upward motion into a ceiling sets +y contact; (5) corner case: moving diagonally into an inside corner slides along one axis when the other is blocked; (6) stepping onto a single block: starting on flat ground next to a 1-block step, a horizontal move into the step blocks horizontal motion (since this resolver does not auto-step), and a separate vertical move can place the AABB on top of the block. Use a getBlock callback backed by a small in-memory Map fixture for tests so this task does NOT depend on chunk.ts. Keep the resolver pure, deterministic, and headless (no Three.js).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*