### PR TITLE
feature: Add targeted-block wireframe highlight in src/render/blockTarget.ts

### DIFF
--- a/src/render/blockTarget.ts
+++ b/src/render/blockTarget.ts
@@ -1,0 +1,30 @@
+import * as THREE from "three";
+
+export interface BlockTargetVoxel {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+export function createBlockTargetMesh(): THREE.LineSegments {
+  const geometry = new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1));
+  const material = new THREE.LineBasicMaterial({ color: 0xffffff });
+  const mesh = new THREE.LineSegments(geometry, material);
+
+  mesh.visible = false;
+
+  return mesh;
+}
+
+export function setBlockTarget(
+  mesh: THREE.LineSegments,
+  voxel: BlockTargetVoxel | null
+): void {
+  if (voxel === null) {
+    mesh.visible = false;
+    return;
+  }
+
+  mesh.visible = true;
+  mesh.position.set(voxel.x + 0.5, voxel.y + 0.5, voxel.z + 0.5);
+}

--- a/tests/render/blockTarget.test.ts
+++ b/tests/render/blockTarget.test.ts
@@ -1,0 +1,36 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+
+import {
+  createBlockTargetMesh,
+  setBlockTarget
+} from "../../src/render/blockTarget";
+
+describe("block target mesh", () => {
+  it("creates a hidden unit-cube wireframe", () => {
+    const mesh = createBlockTargetMesh();
+
+    expect(mesh).toBeInstanceOf(THREE.LineSegments);
+    expect(mesh.geometry).toBeInstanceOf(THREE.EdgesGeometry);
+    expect(mesh.visible).toBe(false);
+  });
+
+  it("positions the target around integer voxel coordinates", () => {
+    const mesh = createBlockTargetMesh();
+
+    setBlockTarget(mesh, { x: 3, y: 5, z: -2 });
+
+    expect(mesh.visible).toBe(true);
+    expect(mesh.position.toArray()).toEqual([3.5, 5.5, -1.5]);
+  });
+
+  it("hides the target without moving it", () => {
+    const mesh = createBlockTargetMesh();
+
+    setBlockTarget(mesh, { x: 3, y: 5, z: -2 });
+    setBlockTarget(mesh, null);
+
+    expect(mesh.visible).toBe(false);
+    expect(mesh.position.toArray()).toEqual([3.5, 5.5, -1.5]);
+  });
+});


### PR DESCRIPTION
## Add targeted-block wireframe highlight in src/render/blockTarget.ts

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #156

### Changes
Create src/render/blockTarget.ts that exports createBlockTargetMesh() and setBlockTarget(mesh, voxel | null). createBlockTargetMesh() should construct and return a THREE.LineSegments unit-cube wireframe outline (e.g. via THREE.EdgesGeometry on a BoxGeometry of size 1, with a THREE.LineBasicMaterial). The mesh should be sized so it visually surrounds an integer-aligned voxel — i.e., a 1x1x1 outline that, when positioned at (vx + 0.5, vy + 0.5, vz + 0.5), wraps the voxel at integer coords (vx, vy, vz). setBlockTarget(mesh, voxel) accepts either a { x: number; y: number; z: number } voxel coord (integers) or null. When given a voxel, set mesh.visible = true and reposition the mesh so its center sits at (x + 0.5, y + 0.5, z + 0.5). When given null, set mesh.visible = false (do not move it). Export a TypeScript type for the voxel coordinate (e.g. `export interface BlockTargetVoxel { x: number; y: number; z: number }`). Add tests/render/blockTarget.test.ts that constructs the mesh, asserts initial visibility is false (or asserts setBlockTarget(null) hides it), asserts setBlockTarget(mesh, { x: 3, y: 5, z: -2 }) makes it visible and positions it at (3.5, 5.5, -1.5), and asserts setBlockTarget(mesh, null) hides it again. Use the real `three` package (already a dependency) — no manual stubbing needed; vitest runs in node and Three.js geometry/mesh objects work without a WebGL context. This module is presentation-only and must not import from src/sim or mutate simulation state.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*