### PR TITLE
feature: Add hotbar selection model in src/sim/hotbar.ts

### DIFF
--- a/src/sim/hotbar.ts
+++ b/src/sim/hotbar.ts
@@ -1,0 +1,46 @@
+import type { Inventory, InventorySlot } from "./inventory";
+
+export interface Hotbar {
+  readonly size: number;
+  readonly selected: number;
+}
+
+export function createHotbar(size: number): Hotbar {
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new Error("Hotbar size must be a positive integer.");
+  }
+
+  return {
+    size,
+    selected: 0
+  };
+}
+
+export function selectSlot(state: Hotbar, index: number): Hotbar {
+  if (!Number.isInteger(index) || index < 0 || index >= state.size) {
+    return state;
+  }
+
+  return {
+    size: state.size,
+    selected: index
+  };
+}
+
+export function nextSlot(state: Hotbar): Hotbar {
+  return {
+    size: state.size,
+    selected: (state.selected + 1) % state.size
+  };
+}
+
+export function prevSlot(state: Hotbar): Hotbar {
+  return {
+    size: state.size,
+    selected: (state.selected - 1 + state.size) % state.size
+  };
+}
+
+export function getSelectedItem(hotbar: Hotbar, inventory: Inventory): InventorySlot | null {
+  return inventory.slots[hotbar.selected] ?? null;
+}

--- a/tests/sim/hotbar.test.ts
+++ b/tests/sim/hotbar.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import {
+  createHotbar,
+  getSelectedItem,
+  nextSlot,
+  prevSlot,
+  selectSlot,
+  type Hotbar
+} from "../../src/sim/hotbar";
+import type { Inventory } from "../../src/sim/inventory";
+
+function makeInventory(slots: Inventory["slots"]): Inventory {
+  return { slots, selectedHotbarSlot: 0 };
+}
+
+describe("hotbar", () => {
+  it("creates an initial hotbar state", () => {
+    expect(createHotbar(9)).toEqual({ size: 9, selected: 0 });
+    expect(() => createHotbar(0)).toThrow("Hotbar size must be a positive integer.");
+    expect(() => createHotbar(-1)).toThrow("Hotbar size must be a positive integer.");
+    expect(() => createHotbar(1.5)).toThrow("Hotbar size must be a positive integer.");
+  });
+
+  it("selects an in-range slot without mutating the input state", () => {
+    const hotbar = createHotbar(9);
+    const result = selectSlot(hotbar, 3);
+
+    expect(result).toEqual({ size: 9, selected: 3 });
+    expect(result).not.toBe(hotbar);
+    expect(hotbar).toEqual({ size: 9, selected: 0 });
+  });
+
+  it("returns the input state for out-of-range selections", () => {
+    const hotbar: Hotbar = { size: 9, selected: 2 };
+
+    for (const index of [-1, 9, Number.NaN, 2.5]) {
+      expect(selectSlot(hotbar, index)).toBe(hotbar);
+    }
+  });
+
+  it("wraps nextSlot from the last slot to the first", () => {
+    const hotbar: Hotbar = { size: 4, selected: 3 };
+    const result = nextSlot(hotbar);
+
+    expect(result).toEqual({ size: 4, selected: 0 });
+    expect(result).not.toBe(hotbar);
+  });
+
+  it("wraps prevSlot from the first slot to the last", () => {
+    const hotbar: Hotbar = { size: 4, selected: 0 };
+    const result = prevSlot(hotbar);
+
+    expect(result).toEqual({ size: 4, selected: 3 });
+    expect(result).not.toBe(hotbar);
+  });
+
+  it("advances deterministically after number-key selection intents", () => {
+    let hotbar = selectSlot(createHotbar(9), 2);
+    const selectedIndices: Array<number> = [];
+
+    for (let step = 0; step < 4; step += 1) {
+      hotbar = nextSlot(hotbar);
+      selectedIndices.push(hotbar.selected);
+    }
+
+    expect(selectedIndices).toEqual([3, 4, 5, 6]);
+  });
+
+  it("returns the inventory slot at the selected hotbar index", () => {
+    const slot = { id: BlockId.STONE, count: 6 };
+    const inventory = makeInventory([null, slot]);
+
+    expect(getSelectedItem({ size: 9, selected: 1 }, inventory)).toBe(slot);
+  });
+
+  it("returns null when the selected inventory slot is empty", () => {
+    const inventory = makeInventory([null]);
+
+    expect(getSelectedItem({ size: 9, selected: 0 }, inventory)).toBeNull();
+  });
+
+  it("returns null when the selected hotbar index is past inventory slots", () => {
+    const inventory = makeInventory([{ id: BlockId.DIRT, count: 1 }]);
+
+    expect(getSelectedItem({ size: 9, selected: 3 }, inventory)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Add hotbar selection model in src/sim/hotbar.ts

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #157

### Changes
Create a deterministic, pure-data hotbar selection module at src/sim/hotbar.ts that owns the 'which slot is currently selected' state independently from inventory and player. Export: (1) an `Hotbar` interface with `size: number` and `selected: number`; (2) `createHotbar(size: number): Hotbar` that initializes selected to 0 and validates size is a positive integer (throw on non-positive or non-integer size); (3) `selectSlot(state: Hotbar, index: number): Hotbar` returning a new Hotbar with selected set to index, clamping/guarding out-of-range indices by returning the input unchanged when index is not an integer in [0, size); (4) `nextSlot(state: Hotbar): Hotbar` and `prevSlot(state: Hotbar): Hotbar` that wrap around modulo size and return new state objects; (5) `getSelectedItem(hotbar: Hotbar, inventory: Inventory): InventorySlot | null` that returns the inventory slot at the hotbar's selected index, or null if the inventory slot is empty or the index is out of range of the inventory's slots array. All functions must be pure (no mutation of inputs) and deterministic. Add tests/sim/hotbar.test.ts covering: initial state from createHotbar, selectSlot in-range, selectSlot out-of-range guards (negative, >= size, NaN, non-integer), nextSlot wrap-around from last to 0, prevSlot wrap-around from 0 to last, repeated nextSlot calls return deterministic indices matching simulated number-key intents (e.g., pressing slot 3 then nextSlot lands on slot 4), getSelectedItem returning inventory slot when present, getSelectedItem returning null for empty slot, getSelectedItem returning null when selected is past inventory.slots.length. Import the existing `Inventory` type from src/sim/inventory.ts and reuse its slot shape — do not redefine inventory types.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*