### PR TITLE
feature: Add createPlayerCamera and applyPlayerPose in src/render/camera.ts

### DIFF
--- a/src/render/camera.ts
+++ b/src/render/camera.ts
@@ -1,0 +1,53 @@
+import * as THREE from "three";
+
+const DEFAULT_PLAYER_CAMERA_FOV = 70;
+const DEFAULT_PLAYER_CAMERA_ASPECT = 1;
+const DEFAULT_PLAYER_CAMERA_NEAR = 0.1;
+const DEFAULT_PLAYER_CAMERA_FAR = 1000;
+
+type PlayerCameraOptions = {
+  readonly fov?: number;
+  readonly aspect?: number;
+  readonly near?: number;
+  readonly far?: number;
+};
+
+export type PlayerPose = {
+  readonly position:
+    | { readonly x: number; readonly y: number; readonly z: number }
+    | readonly [number, number, number];
+  readonly yaw: number;
+  readonly pitch: number;
+};
+
+function isTuplePosition(
+  position: PlayerPose["position"]
+): position is readonly [number, number, number] {
+  return Array.isArray(position);
+}
+
+export function createPlayerCamera(
+  options: PlayerCameraOptions = {}
+): THREE.PerspectiveCamera {
+  return new THREE.PerspectiveCamera(
+    options.fov ?? DEFAULT_PLAYER_CAMERA_FOV,
+    options.aspect ?? DEFAULT_PLAYER_CAMERA_ASPECT,
+    options.near ?? DEFAULT_PLAYER_CAMERA_NEAR,
+    options.far ?? DEFAULT_PLAYER_CAMERA_FAR
+  );
+}
+
+export function applyPlayerPose(
+  camera: THREE.PerspectiveCamera,
+  pose: PlayerPose
+): void {
+  const { position } = pose;
+
+  if (isTuplePosition(position)) {
+    camera.position.set(position[0], position[1], position[2]);
+  } else {
+    camera.position.set(position.x, position.y, position.z);
+  }
+
+  camera.rotation.set(pose.pitch, pose.yaw, 0, "YXZ");
+}

--- a/tests/render/camera.test.ts
+++ b/tests/render/camera.test.ts
@@ -1,0 +1,107 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+
+import { applyPlayerPose, createPlayerCamera } from "../../src/render/camera";
+
+function snapshotStableCameraFields(camera: THREE.PerspectiveCamera) {
+  return {
+    aspect: camera.aspect,
+    far: camera.far,
+    filmGauge: camera.filmGauge,
+    filmOffset: camera.filmOffset,
+    focus: camera.focus,
+    fov: camera.fov,
+    frustumCulled: camera.frustumCulled,
+    layersMask: camera.layers.mask,
+    matrixAutoUpdate: camera.matrixAutoUpdate,
+    matrixWorldAutoUpdate: camera.matrixWorldAutoUpdate,
+    name: camera.name,
+    near: camera.near,
+    renderOrder: camera.renderOrder,
+    scale: camera.scale.toArray(),
+    type: camera.type,
+    up: camera.up.toArray(),
+    visible: camera.visible,
+    zoom: camera.zoom
+  };
+}
+
+describe("createPlayerCamera", () => {
+  it("applies player camera defaults", () => {
+    const camera = createPlayerCamera();
+
+    expect(camera).toBeInstanceOf(THREE.PerspectiveCamera);
+    expect(camera.fov).toBe(70);
+    expect(camera.aspect).toBe(1);
+    expect(camera.near).toBe(0.1);
+    expect(camera.far).toBe(1000);
+  });
+
+  it("applies player camera option overrides", () => {
+    const camera = createPlayerCamera({
+      aspect: 16 / 9,
+      far: 500,
+      fov: 80,
+      near: 0.25
+    });
+
+    expect(camera.fov).toBe(80);
+    expect(camera.aspect).toBe(16 / 9);
+    expect(camera.near).toBe(0.25);
+    expect(camera.far).toBe(500);
+  });
+});
+
+describe("applyPlayerPose", () => {
+  it("mutates the existing position and rotation without changing stable fields", () => {
+    const camera = createPlayerCamera({
+      aspect: 4 / 3,
+      far: 750,
+      fov: 75,
+      near: 0.2
+    });
+    camera.name = "player-camera";
+    camera.scale.set(2, 2, 2);
+    camera.zoom = 1.25;
+
+    const position = camera.position;
+    const rotation = camera.rotation;
+    const stableFields = snapshotStableCameraFields(camera);
+
+    applyPlayerPose(camera, {
+      position: { x: 3, y: 4, z: 5 },
+      yaw: 0.5,
+      pitch: -0.25
+    });
+
+    expect(camera.position).toBe(position);
+    expect(camera.rotation).toBe(rotation);
+    expect(snapshotStableCameraFields(camera)).toEqual(stableFields);
+    expect(camera.position.toArray()).toEqual([3, 4, 5]);
+    expect(camera.rotation.order).toBe("YXZ");
+    expect(camera.rotation.x).toBeCloseTo(-0.25);
+    expect(camera.rotation.y).toBeCloseTo(0.5);
+    expect(camera.rotation.z).toBe(0);
+  });
+
+  it("maps yaw around Y while zero pitch keeps the camera level", () => {
+    const camera = createPlayerCamera();
+    const direction = new THREE.Vector3();
+
+    applyPlayerPose(camera, {
+      position: [0, 0, 0],
+      yaw: Math.PI / 2,
+      pitch: 0
+    });
+
+    camera.getWorldDirection(direction);
+
+    expect(camera.rotation.order).toBe("YXZ");
+    expect(camera.rotation.x).toBeCloseTo(0);
+    expect(camera.rotation.y).toBeCloseTo(Math.PI / 2);
+    expect(camera.rotation.z).toBeCloseTo(0);
+    expect(direction.x).toBeCloseTo(-1);
+    expect(direction.y).toBeCloseTo(0);
+    expect(direction.z).toBeCloseTo(0);
+  });
+});


### PR DESCRIPTION
## Add createPlayerCamera and applyPlayerPose in src/render/camera.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #137

### Changes
Create src/render/camera.ts with two exports: (1) createPlayerCamera(options?: { fov?: number; aspect?: number; near?: number; far?: number }): THREE.PerspectiveCamera that returns a configured PerspectiveCamera with documented defaults (e.g. fov 70, aspect 1, near 0.1, far 1000) matching the current values in src/app.ts; (2) applyPlayerPose(camera: THREE.PerspectiveCamera, pose: PlayerPose): void where PlayerPose is a structural type { position: { x: number; y: number; z: number } | readonly [number, number, number]; yaw: number; pitch: number } that maps to camera.position and camera.rotation (use 'YXZ' rotation order so yaw rotates around Y and pitch around X). Export the PlayerPose type. Add tests/render/camera.test.ts asserting: (a) defaults applied when no options passed; (b) overrides take effect (e.g. custom fov/aspect/near/far); (c) applyPlayerPose mutates ONLY camera.position and camera.rotation — verify camera.fov, near, far, aspect, scale, and other fields are unchanged via a snapshot of those fields before/after the call; (d) yaw/pitch map correctly (e.g. yaw=PI/2 rotates camera, pitch=0 keeps level).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*