### PR TITLE
feature: Add pointer lock adapter in src/input/pointerLock.ts

### DIFF
--- a/src/input/pointerLock.ts
+++ b/src/input/pointerLock.ts
@@ -1,0 +1,148 @@
+export type PointerLockDocumentEventName = "pointerlockchange" | "mousemove";
+
+export interface PointerLockDocument {
+  readonly pointerLockElement: unknown;
+  addEventListener(type: PointerLockDocumentEventName, listener: EventListener): void;
+  removeEventListener(type: PointerLockDocumentEventName, listener: EventListener): void;
+}
+
+export interface PointerLockTarget {
+  readonly ownerDocument?: PointerLockDocument;
+  requestPointerLock(): void | Promise<void>;
+  addEventListener(type: "click", listener: EventListener): void;
+  removeEventListener(type: "click", listener: EventListener): void;
+}
+
+export interface PointerLockLookDeltaEvent {
+  readonly type: "look-delta";
+  readonly movementX: number;
+  readonly movementY: number;
+}
+
+export type PointerLockLookDeltaHandler = (
+  event: PointerLockLookDeltaEvent
+) => void;
+
+export interface PointerLockOptions {
+  readonly document?: PointerLockDocument;
+  readonly emit?: PointerLockLookDeltaHandler;
+}
+
+export interface PointerLockAdapter {
+  isLocked(): boolean;
+  on(handler: PointerLockLookDeltaHandler): () => void;
+  off(handler: PointerLockLookDeltaHandler): void;
+  dispose(): void;
+}
+
+type MouseMovementEvent = Partial<Pick<MouseEvent, "movementX" | "movementY">>;
+
+function defaultDocument(): PointerLockDocument | undefined {
+  return typeof document === "undefined" ? undefined : document;
+}
+
+function isPointerLockDocument(
+  value: PointerLockOptions | PointerLockDocument
+): value is PointerLockDocument {
+  return "addEventListener" in value && "removeEventListener" in value;
+}
+
+export function createPointerLock(
+  target: PointerLockTarget,
+  optionsOrDocument: PointerLockOptions | PointerLockDocument = {}
+): PointerLockAdapter {
+  const options = isPointerLockDocument(optionsOrDocument)
+    ? { document: optionsOrDocument }
+    : optionsOrDocument;
+  const pointerLockDocument =
+    options.document ?? target.ownerDocument ?? defaultDocument();
+
+  if (pointerLockDocument === undefined) {
+    throw new Error("createPointerLock requires a document");
+  }
+
+  const subscribers = new Set<PointerLockLookDeltaHandler>();
+  let disposed = false;
+  let locked = pointerLockDocument.pointerLockElement === target;
+
+  function emit(event: PointerLockLookDeltaEvent): void {
+    if (disposed) {
+      return;
+    }
+
+    options.emit?.(event);
+    for (const subscriber of subscribers) {
+      subscriber(event);
+    }
+  }
+
+  const handleClick: EventListener = () => {
+    if (!disposed) {
+      void target.requestPointerLock();
+    }
+  };
+
+  const handlePointerLockChange: EventListener = () => {
+    locked = pointerLockDocument.pointerLockElement === target;
+  };
+
+  const handleMouseMove: EventListener = (event) => {
+    if (!locked) {
+      return;
+    }
+
+    const { movementX = 0, movementY = 0 } = event as MouseMovementEvent;
+    emit({ type: "look-delta", movementX, movementY });
+  };
+
+  const targetListeners: ReadonlyArray<readonly ["click", EventListener]> = [
+    ["click", handleClick]
+  ];
+  const documentListeners: ReadonlyArray<
+    readonly [PointerLockDocumentEventName, EventListener]
+  > = [
+    ["pointerlockchange", handlePointerLockChange],
+    ["mousemove", handleMouseMove]
+  ];
+
+  for (const [type, listener] of targetListeners) {
+    target.addEventListener(type, listener);
+  }
+  for (const [type, listener] of documentListeners) {
+    pointerLockDocument.addEventListener(type, listener);
+  }
+
+  return {
+    isLocked() {
+      return locked;
+    },
+    on(handler) {
+      if (disposed) {
+        return () => undefined;
+      }
+
+      subscribers.add(handler);
+      return () => {
+        subscribers.delete(handler);
+      };
+    },
+    off(handler) {
+      subscribers.delete(handler);
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+
+      disposed = true;
+      for (const [type, listener] of targetListeners) {
+        target.removeEventListener(type, listener);
+      }
+      for (const [type, listener] of documentListeners) {
+        pointerLockDocument.removeEventListener(type, listener);
+      }
+      subscribers.clear();
+      locked = false;
+    }
+  };
+}

--- a/tests/input/pointerLock.test.ts
+++ b/tests/input/pointerLock.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createPointerLock,
+  type PointerLockDocument,
+  type PointerLockDocumentEventName,
+  type PointerLockLookDeltaEvent,
+  type PointerLockTarget
+} from "../../src/input/pointerLock";
+
+interface ListenerRecord {
+  readonly source: "target" | "document";
+  readonly type: string;
+  readonly listener: EventListener;
+}
+
+class FakeEventSource {
+  readonly added: ListenerRecord[] = [];
+  readonly removed: ListenerRecord[] = [];
+  private readonly listeners = new Map<string, Set<EventListener>>();
+
+  constructor(private readonly source: ListenerRecord["source"]) {}
+
+  addEventListener(type: string, listener: EventListener): void {
+    const listenersForType = this.listeners.get(type) ?? new Set<EventListener>();
+    listenersForType.add(listener);
+    this.listeners.set(type, listenersForType);
+    this.added.push({ source: this.source, type, listener });
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    this.listeners.get(type)?.delete(listener);
+    this.removed.push({ source: this.source, type, listener });
+  }
+
+  dispatch(type: string, event: Event): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+}
+
+class FakePointerLockTarget
+  extends FakeEventSource
+  implements PointerLockTarget
+{
+  requestPointerLockCalls = 0;
+
+  constructor() {
+    super("target");
+  }
+
+  requestPointerLock(): void {
+    this.requestPointerLockCalls += 1;
+  }
+}
+
+class FakePointerLockDocument
+  extends FakeEventSource
+  implements PointerLockDocument
+{
+  pointerLockElement: unknown = null;
+
+  constructor() {
+    super("document");
+  }
+
+  override addEventListener(
+    type: PointerLockDocumentEventName,
+    listener: EventListener
+  ): void {
+    super.addEventListener(type, listener);
+  }
+
+  override removeEventListener(
+    type: PointerLockDocumentEventName,
+    listener: EventListener
+  ): void {
+    super.removeEventListener(type, listener);
+  }
+}
+
+function syntheticMouseMove(
+  movementX: number,
+  movementY: number
+): Event {
+  const event = new Event("mousemove");
+  Object.defineProperty(event, "movementX", { value: movementX });
+  Object.defineProperty(event, "movementY", { value: movementY });
+  return event;
+}
+
+function expectRemovedPairs(added: ListenerRecord[], removed: ListenerRecord[]): void {
+  expect(removed).toHaveLength(added.length);
+
+  for (const addedRecord of added) {
+    expect(
+      removed.some(
+        (removedRecord) =>
+          removedRecord.source === addedRecord.source &&
+          removedRecord.type === addedRecord.type &&
+          removedRecord.listener === addedRecord.listener
+      )
+    ).toBe(true);
+  }
+}
+
+describe("pointer lock adapter", () => {
+  it("requests pointer lock when the target is clicked", () => {
+    const target = new FakePointerLockTarget();
+    const pointerLockDocument = new FakePointerLockDocument();
+    const adapter = createPointerLock(target, { document: pointerLockDocument });
+
+    target.dispatch("click", new Event("click"));
+
+    expect(target.requestPointerLockCalls).toBe(1);
+
+    adapter.dispose();
+  });
+
+  it("tracks pointer lock state from document changes", () => {
+    const target = new FakePointerLockTarget();
+    const pointerLockDocument = new FakePointerLockDocument();
+    const adapter = createPointerLock(target, { document: pointerLockDocument });
+
+    expect(adapter.isLocked()).toBe(false);
+
+    pointerLockDocument.pointerLockElement = target;
+    pointerLockDocument.dispatch(
+      "pointerlockchange",
+      new Event("pointerlockchange")
+    );
+    expect(adapter.isLocked()).toBe(true);
+
+    pointerLockDocument.pointerLockElement = null;
+    pointerLockDocument.dispatch(
+      "pointerlockchange",
+      new Event("pointerlockchange")
+    );
+    expect(adapter.isLocked()).toBe(false);
+
+    adapter.dispose();
+  });
+
+  it("emits look-delta events only while locked", () => {
+    const target = new FakePointerLockTarget();
+    const pointerLockDocument = new FakePointerLockDocument();
+    const adapter = createPointerLock(target, { document: pointerLockDocument });
+    const emitted: PointerLockLookDeltaEvent[] = [];
+
+    adapter.on((event) => {
+      emitted.push(event);
+    });
+
+    pointerLockDocument.dispatch("mousemove", syntheticMouseMove(4, -3));
+
+    pointerLockDocument.pointerLockElement = target;
+    pointerLockDocument.dispatch(
+      "pointerlockchange",
+      new Event("pointerlockchange")
+    );
+    pointerLockDocument.dispatch("mousemove", syntheticMouseMove(7, 2));
+
+    pointerLockDocument.pointerLockElement = null;
+    pointerLockDocument.dispatch(
+      "pointerlockchange",
+      new Event("pointerlockchange")
+    );
+    pointerLockDocument.dispatch("mousemove", syntheticMouseMove(1, 1));
+
+    expect(emitted).toEqual([{ type: "look-delta", movementX: 7, movementY: 2 }]);
+
+    adapter.dispose();
+  });
+
+  it("removes every listener it added on dispose", () => {
+    const target = new FakePointerLockTarget();
+    const pointerLockDocument = new FakePointerLockDocument();
+    const adapter = createPointerLock(target, { document: pointerLockDocument });
+    const added = [...target.added, ...pointerLockDocument.added];
+
+    adapter.dispose();
+
+    expectRemovedPairs(added, [...target.removed, ...pointerLockDocument.removed]);
+    expect(target.listenerCount("click")).toBe(0);
+    expect(pointerLockDocument.listenerCount("pointerlockchange")).toBe(0);
+    expect(pointerLockDocument.listenerCount("mousemove")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Add pointer lock adapter in src/input/pointerLock.ts

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #133

### Changes
Create src/input/pointerLock.ts exporting createPointerLock(target) that: (1) attaches a click listener on the target HTMLElement-like object that calls target.requestPointerLock(); (2) listens for 'pointerlockchange' on document (or an injectable document for testability) to track lock state; (3) exposes an isLocked() getter; (4) emits look-delta events derived from 'mousemove' movementX/movementY when locked, via an on(handler)/off(handler) subscription API or an injected emit callback that the mouse adapter can consume; (5) returns a dispose() function that removes every listener it added so tests can verify cleanup. The module must NOT import from src/sim or src/render — only browser DOM types and any local input types. Add tests/input/pointerLock.test.ts that constructs a fake target element with stubbed addEventListener/removeEventListener/requestPointerLock and a fake document, then asserts: clicking calls requestPointerLock; pointerlockchange flips isLocked() correctly; mousemove emits look-delta events only while locked; dispose() removes every listener that was added (track add/remove pairs).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*