### PR TITLE
feature: Add voxel chunk mesh builder in src/render/chunkMesh.ts

### DIFF
--- a/src/render/chunkMesh.ts
+++ b/src/render/chunkMesh.ts
@@ -1,0 +1,196 @@
+import * as THREE from "three";
+
+import { BLOCK_REGISTRY, BlockId } from "../sim/blocks";
+import { CHUNK_SIZE, chunkIndex, type Chunk } from "../sim/chunk";
+
+type Vec3 = readonly [number, number, number];
+
+export type BlockFaceUV = readonly [
+  readonly [number, number],
+  readonly [number, number],
+  readonly [number, number],
+  readonly [number, number]
+];
+
+interface FaceDefinition {
+  readonly offset: Vec3;
+  readonly normal: Vec3;
+  readonly corners: readonly [Vec3, Vec3, Vec3, Vec3];
+}
+
+const DEFAULT_FACE_UV = [
+  [0, 0],
+  [1, 0],
+  [1, 1],
+  [0, 1]
+] as const satisfies BlockFaceUV;
+
+const BLOCK_FACE_UVS = {
+  [BlockId.AIR]: DEFAULT_FACE_UV,
+  [BlockId.GRASS]: DEFAULT_FACE_UV,
+  [BlockId.DIRT]: DEFAULT_FACE_UV,
+  [BlockId.STONE]: DEFAULT_FACE_UV,
+  [BlockId.WOOD]: DEFAULT_FACE_UV,
+  [BlockId.PLANKS]: DEFAULT_FACE_UV,
+  [BlockId.STICK]: DEFAULT_FACE_UV,
+  [BlockId.COAL]: DEFAULT_FACE_UV,
+  [BlockId.TORCH]: DEFAULT_FACE_UV
+} as const satisfies Readonly<Record<BlockId, BlockFaceUV>>;
+
+const FACE_DEFINITIONS: readonly FaceDefinition[] = [
+  {
+    offset: [1, 0, 0],
+    normal: [1, 0, 0],
+    corners: [
+      [1, 0, 0],
+      [1, 1, 0],
+      [1, 1, 1],
+      [1, 0, 1]
+    ]
+  },
+  {
+    offset: [-1, 0, 0],
+    normal: [-1, 0, 0],
+    corners: [
+      [0, 0, 0],
+      [0, 0, 1],
+      [0, 1, 1],
+      [0, 1, 0]
+    ]
+  },
+  {
+    offset: [0, 1, 0],
+    normal: [0, 1, 0],
+    corners: [
+      [0, 1, 0],
+      [0, 1, 1],
+      [1, 1, 1],
+      [1, 1, 0]
+    ]
+  },
+  {
+    offset: [0, -1, 0],
+    normal: [0, -1, 0],
+    corners: [
+      [0, 0, 0],
+      [1, 0, 0],
+      [1, 0, 1],
+      [0, 0, 1]
+    ]
+  },
+  {
+    offset: [0, 0, 1],
+    normal: [0, 0, 1],
+    corners: [
+      [0, 0, 1],
+      [1, 0, 1],
+      [1, 1, 1],
+      [0, 1, 1]
+    ]
+  },
+  {
+    offset: [0, 0, -1],
+    normal: [0, 0, -1],
+    corners: [
+      [0, 0, 0],
+      [0, 1, 0],
+      [1, 1, 0],
+      [1, 0, 0]
+    ]
+  }
+];
+
+export function getBlockFaceUV(blockId: BlockId): BlockFaceUV {
+  return BLOCK_FACE_UVS[blockId];
+}
+
+export function buildChunkMesh(chunk: Chunk): THREE.BufferGeometry {
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const uvs: number[] = [];
+  const indices: number[] = [];
+
+  for (let y = 0; y < CHUNK_SIZE; y += 1) {
+    for (let z = 0; z < CHUNK_SIZE; z += 1) {
+      for (let x = 0; x < CHUNK_SIZE; x += 1) {
+        const blockId = chunk.blocks[chunkIndex(x, y, z)];
+
+        if (!isSolidBlock(blockId)) {
+          continue;
+        }
+
+        for (const face of FACE_DEFINITIONS) {
+          const [offsetX, offsetY, offsetZ] = face.offset;
+
+          if (isSolidNeighbor(chunk, x + offsetX, y + offsetY, z + offsetZ)) {
+            continue;
+          }
+
+          appendFace(positions, normals, uvs, indices, x, y, z, blockId as BlockId, face);
+        }
+      }
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry();
+
+  geometry.setAttribute("position", new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute("normal", new THREE.Float32BufferAttribute(normals, 3));
+  geometry.setAttribute("uv", new THREE.Float32BufferAttribute(uvs, 2));
+  geometry.setIndex(indices);
+
+  return geometry;
+}
+
+function appendFace(
+  positions: number[],
+  normals: number[],
+  uvs: number[],
+  indices: number[],
+  x: number,
+  y: number,
+  z: number,
+  blockId: BlockId,
+  face: FaceDefinition
+): void {
+  const vertexOffset = positions.length / 3;
+  const faceUV = getBlockFaceUV(blockId);
+
+  for (let vertexIndex = 0; vertexIndex < face.corners.length; vertexIndex += 1) {
+    const [cornerX, cornerY, cornerZ] = face.corners[vertexIndex];
+    const [normalX, normalY, normalZ] = face.normal;
+    const [u, v] = faceUV[vertexIndex];
+
+    positions.push(x + cornerX, y + cornerY, z + cornerZ);
+    normals.push(normalX, normalY, normalZ);
+    uvs.push(u, v);
+  }
+
+  indices.push(
+    vertexOffset,
+    vertexOffset + 1,
+    vertexOffset + 2,
+    vertexOffset,
+    vertexOffset + 2,
+    vertexOffset + 3
+  );
+}
+
+function isSolidNeighbor(chunk: Chunk, x: number, y: number, z: number): boolean {
+  if (
+    x < 0 ||
+    x >= CHUNK_SIZE ||
+    y < 0 ||
+    y >= CHUNK_SIZE ||
+    z < 0 ||
+    z >= CHUNK_SIZE
+  ) {
+    return false;
+  }
+
+  return isSolidBlock(chunk.blocks[chunkIndex(x, y, z)]);
+}
+
+function isSolidBlock(blockId: number): boolean {
+  return BLOCK_REGISTRY[blockId as BlockId]?.solid === true;
+}

--- a/tests/render/chunkMesh.test.ts
+++ b/tests/render/chunkMesh.test.ts
@@ -1,0 +1,73 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+
+import { buildChunkMesh } from "../../src/render/chunkMesh";
+import { BlockId } from "../../src/sim/blocks";
+import { CHUNK_SIZE, createChunk, setBlock } from "../../src/sim/chunk";
+
+describe("buildChunkMesh", () => {
+  it("produces zero faces for an all-air chunk", () => {
+    const geometry = buildChunkMesh(createChunk());
+
+    expect(geometry.getIndex()?.count).toBe(0);
+    expect(getFaceCount(geometry)).toBe(0);
+  });
+
+  it("emits six faces for a single solid block surrounded by air", () => {
+    const chunk = createChunk();
+
+    setBlock(chunk, 4, 5, 6, BlockId.STONE);
+
+    const geometry = buildChunkMesh(chunk);
+
+    expect(getFaceCount(geometry)).toBe(6);
+    expect(geometry.getIndex()?.count).toBe(36);
+    expect(geometry.getAttribute("position").count).toBe(24);
+  });
+
+  it("omits the internal face between adjacent solid blocks", () => {
+    const chunk = createChunk();
+
+    setBlock(chunk, 4, 5, 6, BlockId.STONE);
+    setBlock(chunk, 5, 5, 6, BlockId.DIRT);
+
+    expect(getFaceCount(buildChunkMesh(chunk))).toBe(10);
+  });
+
+  it("emits only the exterior shell for a fully solid chunk", () => {
+    const chunk = createChunk();
+
+    chunk.blocks.fill(BlockId.STONE);
+
+    expect(getFaceCount(buildChunkMesh(chunk))).toBe(CHUNK_SIZE * CHUNK_SIZE * 6);
+  });
+
+  it("returns a BufferGeometry with indexed position, normal, and uv attributes", () => {
+    const chunk = createChunk();
+
+    setBlock(chunk, 4, 5, 6, BlockId.STONE);
+
+    const geometry = buildChunkMesh(chunk);
+    const position = geometry.getAttribute("position");
+    const normal = geometry.getAttribute("normal");
+    const uv = geometry.getAttribute("uv");
+
+    expect(geometry).toBeInstanceOf(THREE.BufferGeometry);
+    expect(geometry.getIndex()).not.toBeNull();
+    expect(position).toBeInstanceOf(THREE.BufferAttribute);
+    expect(normal).toBeInstanceOf(THREE.BufferAttribute);
+    expect(uv).toBeInstanceOf(THREE.BufferAttribute);
+    expect(normal.count).toBe(position.count);
+    expect(uv.count).toBe(position.count);
+  });
+});
+
+function getFaceCount(geometry: THREE.BufferGeometry): number {
+  const index = geometry.getIndex();
+
+  if (index === null) {
+    throw new Error("Expected indexed chunk geometry");
+  }
+
+  return index.count / 6;
+}


### PR DESCRIPTION
## Add voxel chunk mesh builder in src/render/chunkMesh.ts

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #138

### Changes
Create src/render/chunkMesh.ts exporting a pure function `buildChunkMesh(chunk: Chunk): THREE.BufferGeometry` (or similar) that walks the chunk's voxels and emits geometry only for faces between a solid voxel and a non-solid (air or non-existent) neighbor. Use BLOCK_REGISTRY.solid from src/sim/blocks.ts to decide solidity. For each emitted face, write per-vertex positions (4 vertices per face, indexed as two triangles), normals matching the face direction, and UVs from a small block→uv lookup table (a default 0..1 quad mapping is acceptable as long as it is centralized in this module). Provide a small per-block material/uv lookup helper exported from the same module (e.g. `getBlockFaceUV(blockId)` returning a 4-corner uv quad) — keep it minimal but covering the registered block ids. The module must NOT touch the DOM, instantiate a Renderer, or import anything that requires a browser; only `three` and src/sim modules. In tests/render/chunkMesh.test.ts, use vitest with the existing test setup (no Playwright, no jsdom-needed APIs) and assert: (1) an all-air chunk produces zero faces (index count === 0), (2) a chunk with a single solid block surrounded by air produces exactly 6 faces (12 triangles, 36 indices, 24 unique vertex positions), (3) two adjacent solid blocks share no internal face — total faces === 10 instead of 12, (4) a fully solid chunk emits only the exterior shell (CHUNK_SIZE*CHUNK_SIZE*6 faces), (5) the returned object exposes BufferGeometry-shaped attributes (`position`, `normal`, `uv`) and an index. Use `import * as THREE from 'three'` in source; tests can read attribute counts via `geometry.getAttribute('position').count` and `geometry.getIndex()?.count`.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*