### PR TITLE
feature: Add DDA voxel raycaster in src/sim/raycast.ts

### DIFF
--- a/src/sim/raycast.ts
+++ b/src/sim/raycast.ts
@@ -1,0 +1,182 @@
+import { getBlockDefinition, type BlockId } from "./blocks";
+
+export type Vec3 = readonly [number, number, number];
+
+export interface Vec3Object {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+export type Vec3Like = Vec3 | Vec3Object;
+export type BlockGetter = (x: number, y: number, z: number) => BlockId;
+export type AxisDirection = -1 | 0 | 1;
+export type FaceNormal = readonly [AxisDirection, AxisDirection, AxisDirection];
+
+export interface RaycastHit {
+  readonly block: Vec3;
+  readonly placement: Vec3;
+  readonly normal: FaceNormal;
+  readonly distance: number;
+}
+
+type Axis = 0 | 1 | 2;
+type MutableVec3 = [number, number, number];
+type MutableStepVec3 = [AxisDirection, AxisDirection, AxisDirection];
+
+export function raycast(
+  origin: Vec3Like,
+  direction: Vec3,
+  maxDistance: number,
+  getBlock: BlockGetter
+): RaycastHit | null {
+  const originVec = toVec3(origin);
+  const voxel: MutableVec3 = [
+    Math.floor(originVec[0]),
+    Math.floor(originVec[1]),
+    Math.floor(originVec[2])
+  ];
+
+  if (isSolid(getBlock, voxel)) {
+    return {
+      block: [...voxel],
+      placement: [...voxel],
+      normal: [0, 0, 0],
+      distance: 0
+    };
+  }
+
+  if (!Number.isFinite(maxDistance) || maxDistance < 0) {
+    return null;
+  }
+
+  const step: MutableStepVec3 = [
+    getStep(direction[0]),
+    getStep(direction[1]),
+    getStep(direction[2])
+  ];
+  const tDelta: MutableVec3 = [
+    getTDelta(direction[0]),
+    getTDelta(direction[1]),
+    getTDelta(direction[2])
+  ];
+  const tMax: MutableVec3 = [
+    getInitialTMax(originVec[0], voxel[0], direction[0], step[0]),
+    getInitialTMax(originVec[1], voxel[1], direction[1], step[1]),
+    getInitialTMax(originVec[2], voxel[2], direction[2], step[2])
+  ];
+
+  let distance = 0;
+
+  while (distance <= maxDistance) {
+    const axis = getNextAxis(tMax);
+    distance = tMax[axis];
+
+    if (distance > maxDistance) {
+      return null;
+    }
+
+    const placement: MutableVec3 = [...voxel];
+    voxel[axis] += step[axis];
+
+    if (isSolid(getBlock, voxel)) {
+      return {
+        block: [...voxel],
+        placement,
+        normal: getNormal(axis, step[axis]),
+        distance
+      };
+    }
+
+    tMax[axis] += tDelta[axis];
+  }
+
+  return null;
+}
+
+function toVec3(value: Vec3Like): Vec3 {
+  if ("x" in value) {
+    return [value.x, value.y, value.z];
+  }
+
+  return value;
+}
+
+function getStep(value: number): AxisDirection {
+  if (value > 0) {
+    return 1;
+  }
+
+  if (value < 0) {
+    return -1;
+  }
+
+  return 0;
+}
+
+function getTDelta(direction: number): number {
+  if (direction === 0) {
+    return Infinity;
+  }
+
+  return Math.abs(1 / direction);
+}
+
+function getInitialTMax(
+  origin: number,
+  voxel: number,
+  direction: number,
+  step: AxisDirection
+): number {
+  if (step > 0) {
+    return (voxel + 1 - origin) / direction;
+  }
+
+  if (step < 0) {
+    return (origin - voxel) / -direction;
+  }
+
+  return Infinity;
+}
+
+function getNextAxis(tMax: Readonly<MutableVec3>): Axis {
+  if (tMax[0] <= tMax[1] && tMax[0] <= tMax[2]) {
+    return 0;
+  }
+
+  if (tMax[1] <= tMax[2]) {
+    return 1;
+  }
+
+  return 2;
+}
+
+function getNormal(axis: Axis, step: AxisDirection): FaceNormal {
+  const normalStep = invertStep(step);
+
+  if (axis === 0) {
+    return [normalStep, 0, 0];
+  }
+
+  if (axis === 1) {
+    return [0, normalStep, 0];
+  }
+
+  return [0, 0, normalStep];
+}
+
+function invertStep(step: AxisDirection): AxisDirection {
+  if (step === 1) {
+    return -1;
+  }
+
+  if (step === -1) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function isSolid(getBlock: BlockGetter, voxel: Readonly<MutableVec3>): boolean {
+  return getBlockDefinition(getBlock(voxel[0], voxel[1], voxel[2])).solid;
+}

--- a/tests/sim/raycast.test.ts
+++ b/tests/sim/raycast.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import {
+  raycast,
+  type BlockGetter,
+  type FaceNormal,
+  type RaycastHit,
+  type Vec3
+} from "../../src/sim/raycast";
+
+interface AxisCase {
+  readonly name: string;
+  readonly block: Vec3;
+  readonly direction: Vec3;
+  readonly placement: Vec3;
+  readonly normal: FaceNormal;
+}
+
+interface FaceCase {
+  readonly name: string;
+  readonly origin: Vec3;
+  readonly direction: Vec3;
+  readonly placement: Vec3;
+  readonly normal: FaceNormal;
+}
+
+interface ExpectedHit {
+  readonly block: Vec3;
+  readonly placement: Vec3;
+  readonly normal: FaceNormal;
+  readonly distance: number;
+}
+
+const ORIGIN: Vec3 = [0.5, 0.5, 0.5];
+const AXIS_CASES: readonly AxisCase[] = [
+  { name: "+X", block: [2, 0, 0], direction: [1, 0, 0], placement: [1, 0, 0], normal: [-1, 0, 0] },
+  { name: "-X", block: [-2, 0, 0], direction: [-1, 0, 0], placement: [-1, 0, 0], normal: [1, 0, 0] },
+  { name: "+Y", block: [0, 2, 0], direction: [0, 1, 0], placement: [0, 1, 0], normal: [0, -1, 0] },
+  { name: "-Y", block: [0, -2, 0], direction: [0, -1, 0], placement: [0, -1, 0], normal: [0, 1, 0] },
+  { name: "+Z", block: [0, 0, 2], direction: [0, 0, 1], placement: [0, 0, 1], normal: [0, 0, -1] },
+  { name: "-Z", block: [0, 0, -2], direction: [0, 0, -1], placement: [0, 0, -1], normal: [0, 0, 1] }
+];
+const FACE_CASES: readonly FaceCase[] = [
+  { name: "+X", origin: [2.5, 0.5, 0.5], direction: [-1, 0, 0], placement: [1, 0, 0], normal: [1, 0, 0] },
+  { name: "-X", origin: [-1.5, 0.5, 0.5], direction: [1, 0, 0], placement: [-1, 0, 0], normal: [-1, 0, 0] },
+  { name: "+Y", origin: [0.5, 2.5, 0.5], direction: [0, -1, 0], placement: [0, 1, 0], normal: [0, 1, 0] },
+  { name: "-Y", origin: [0.5, -1.5, 0.5], direction: [0, 1, 0], placement: [0, -1, 0], normal: [0, -1, 0] },
+  { name: "+Z", origin: [0.5, 0.5, 2.5], direction: [0, 0, -1], placement: [0, 0, 1], normal: [0, 0, 1] },
+  { name: "-Z", origin: [0.5, 0.5, -1.5], direction: [0, 0, 1], placement: [0, 0, -1], normal: [0, 0, -1] }
+];
+
+describe("raycast", () => {
+  it.each(AXIS_CASES)(
+    "hits a solid block with an axis-aligned $name ray",
+    ({ block, direction, placement, normal }) => {
+      expectHit(raycast(ORIGIN, direction, 10, blocks([block])), {
+        block,
+        placement,
+        normal,
+        distance: 1.5
+      });
+    }
+  );
+
+  it("traverses multiple voxels before a diagonal hit", () => {
+    expectHit(raycast({ x: 0.2, y: 0.2, z: 0.5 }, [0.6, 0.8, 0], 10, blocks([[2, 2, 0]])), {
+      block: [2, 2, 0],
+      placement: [1, 2, 0],
+      normal: [-1, 0, 0],
+      distance: 3
+    });
+  });
+
+  it("returns null when no solid block is hit within maxDistance", () => {
+    expect(raycast(ORIGIN, [1, 0, 0], 2.9, blocks([[4, 0, 0]]))).toBeNull();
+  });
+
+  it.each(FACE_CASES)(
+    "reports the $name face normal when approaching a single block",
+    ({ origin, direction, placement, normal }) => {
+      expectHit(raycast(origin, direction, 10, blocks([[0, 0, 0]])), {
+        block: [0, 0, 0],
+        placement,
+        normal,
+        distance: 1.5
+      });
+    }
+  );
+
+  it("returns distance zero when the ray starts inside a solid block", () => {
+    expectHit(raycast([1.25, 2.25, 3.25], [1, 0, 0], 10, blocks([[1, 2, 3]])), {
+      block: [1, 2, 3],
+      placement: [1, 2, 3],
+      normal: [0, 0, 0],
+      distance: 0
+    });
+  });
+});
+
+function blocks(cells: readonly Vec3[]): BlockGetter {
+  const solidCells = new Map(cells.map((cell) => [key(cell[0], cell[1], cell[2]), BlockId.STONE]));
+
+  return (x: number, y: number, z: number) => solidCells.get(key(x, y, z)) ?? BlockId.AIR;
+}
+
+function key(x: number, y: number, z: number): string {
+  return `${x},${y},${z}`;
+}
+
+function expectHit(hit: RaycastHit | null, expected: ExpectedHit): void {
+  expect(hit).not.toBeNull();
+
+  if (hit === null) {
+    return;
+  }
+
+  expect(hit.block).toEqual(expected.block);
+  expect(hit.placement).toEqual(expected.placement);
+  expect(hit.normal).toEqual(expected.normal);
+  expect(hit.distance).toBeCloseTo(expected.distance);
+}


### PR DESCRIPTION
## Add DDA voxel raycaster in src/sim/raycast.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #106

### Changes
Create a pure, render-free DDA voxel raycaster in src/sim/raycast.ts. Export a `raycast(origin, direction, maxDistance, getBlock)` function where origin is a 3-tuple (or {x,y,z}) world-space position, direction is a 3-tuple unit vector, maxDistance is a positive number, and getBlock is a callback `(x: number, y: number, z: number) => BlockId` returning the block at integer voxel coordinates. The function returns either `null` (no solid block hit within maxDistance) or a hit object containing: the integer voxel coordinates of the hit block, the integer voxel coordinates of the adjacent empty cell suitable for placement (the cell the ray entered from), the face normal as a 3-tuple of -1/0/1 (e.g., [1,0,0] for +X face), and the distance traveled to the hit. Use the standard Amanatides & Woo DDA algorithm: compute initial voxel from floor(origin), step direction sign per axis, tDelta per axis, tMax per axis, then repeatedly advance along the smallest tMax, recording which axis advanced (this determines the face normal opposite to the step direction). A block is considered solid if `BLOCK_REGISTRY[id].solid` is true — query via the imported registry/getBlockDefinition. Handle direction components of zero by setting tDelta/tMax to Infinity for those axes. Treat the starting voxel: if origin is already inside a solid block, return that voxel as the hit with normal [0,0,0] and distance 0 (placement cell equals hit cell). Add tests/sim/raycast.test.ts covering: (1) axis-aligned rays along +X, -X, +Y, -Y, +Z, -Z each hitting a solid block at a known distance with correct face normal and placement cell; (2) a diagonal ray that traverses multiple voxels before hitting a solid one; (3) a ray that exits maxDistance without hitting any solid block returns null; (4) all six face normals are produced correctly when approaching a single solid block from each side; (5) a ray starting inside a solid block returns distance 0. Use small fixed worlds defined inline as Map<string,BlockId> or 3D arrays via the getBlock callback — do NOT depend on Chunk or world generation modules.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*