### PR TITLE
feature: Add localStorage save persistence adapter in src/sim/saveStorage.ts

### DIFF
--- a/src/sim/saveStorage.ts
+++ b/src/sim/saveStorage.ts
@@ -1,0 +1,59 @@
+import {
+  deserializeSave,
+  serializeSave,
+  type SaveState
+} from "./save";
+
+export type SaveStorageResult =
+  | { ok: true }
+  | { ok: false; error: "quota_exceeded" };
+
+export type LoadStorageResult =
+  | { ok: true; state: SaveState }
+  | { ok: false; error: "missing" | "malformed" };
+
+function isQuotaExceededError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const candidate = error as { readonly name?: unknown; readonly code?: unknown };
+
+  return candidate.name === "QuotaExceededError" || candidate.code === 22;
+}
+
+export function saveToStorage(
+  key: string,
+  snapshot: SaveState,
+  storage: Storage
+): SaveStorageResult {
+  const payload = serializeSave(snapshot);
+
+  try {
+    storage.setItem(key, payload);
+  } catch (error) {
+    if (isQuotaExceededError(error)) {
+      return { ok: false, error: "quota_exceeded" };
+    }
+
+    throw error;
+  }
+
+  return { ok: true };
+}
+
+export function loadFromStorage(key: string, storage: Storage): LoadStorageResult {
+  const payload = storage.getItem(key);
+
+  if (payload === null) {
+    return { ok: false, error: "missing" };
+  }
+
+  const result = deserializeSave(payload);
+
+  if (!result.ok) {
+    return { ok: false, error: "malformed" };
+  }
+
+  return { ok: true, state: result.state };
+}

--- a/tests/sim/saveStorage.test.ts
+++ b/tests/sim/saveStorage.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import { SAVE_VERSION, type SaveState } from "../../src/sim/save";
+import { loadFromStorage, saveToStorage } from "../../src/sim/saveStorage";
+
+class MemoryStorage implements Storage {
+  [name: string]: unknown;
+
+  private readonly values = new Map<string, string>();
+
+  public setError: unknown = null;
+
+  public get length(): number {
+    return this.values.size;
+  }
+
+  public clear(): void {
+    this.values.clear();
+  }
+
+  public getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  public key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  public removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  public setItem(key: string, value: string): void {
+    if (this.setError !== null) {
+      throw this.setError;
+    }
+
+    this.values.set(key, value);
+  }
+}
+
+const baseState: SaveState = {
+  version: SAVE_VERSION,
+  seed: 12345,
+  mutations: [
+    { x: 1, y: 4, z: 2, block: BlockId.DIRT },
+    { x: -3, y: 7, z: 9, block: BlockId.AIR },
+    { x: 32, y: 5, z: -16, block: BlockId.TORCH }
+  ],
+  player: {
+    position: [10.5, 12, -3.25],
+    orientation: {
+      yaw: 1.25,
+      pitch: -0.5
+    }
+  },
+  inventory: {
+    slots: [
+      { block: BlockId.GRASS, count: 12 },
+      null,
+      { block: BlockId.TORCH, count: 3 }
+    ]
+  },
+  hotbar: {
+    selected: 2
+  }
+};
+
+describe("save storage", () => {
+  it("round-trips save state through storage", () => {
+    const storage = new MemoryStorage();
+
+    expect(saveToStorage("save", baseState, storage)).toEqual({ ok: true });
+    expect(loadFromStorage("save", storage)).toEqual({ ok: true, state: baseState });
+  });
+
+  it("returns missing for absent storage keys", () => {
+    const storage = new MemoryStorage();
+
+    expect(loadFromStorage("missing", storage)).toEqual({ ok: false, error: "missing" });
+  });
+
+  it("returns malformed for invalid JSON or invalid save shape", () => {
+    const storage = new MemoryStorage();
+
+    storage.setItem("bad-json", "{not json");
+    storage.setItem("bad-shape", JSON.stringify({ version: SAVE_VERSION }));
+
+    expect(loadFromStorage("bad-json", storage)).toEqual({ ok: false, error: "malformed" });
+    expect(loadFromStorage("bad-shape", storage)).toEqual({ ok: false, error: "malformed" });
+  });
+
+  it("returns quota_exceeded when storage quota is exceeded", () => {
+    const storage = new MemoryStorage();
+
+    storage.setError = { name: "QuotaExceededError" };
+
+    expect(saveToStorage("save", baseState, storage)).toEqual({
+      ok: false,
+      error: "quota_exceeded"
+    });
+  });
+});


### PR DESCRIPTION
## Add localStorage save persistence adapter in src/sim/saveStorage.ts

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #169

### Changes
Create src/sim/saveStorage.ts that wraps the existing save codec from src/sim/save.ts (serializeSave / deserializeSave / SAVE_VERSION / SaveState). Export two functions: (1) saveToStorage(key: string, snapshot: SaveState, storage: Storage): SaveStorageResult and (2) loadFromStorage(key: string, storage: Storage): LoadStorageResult. The Storage parameter must be typed against the standard DOM Storage-like shape (getItem/setItem/removeItem) so tests can pass an in-memory fake without a browser. saveToStorage should call serializeSave(snapshot), JSON-encode the codec output (the codec already returns a string, so wrap it via storage.setItem(key, payload)), and catch QuotaExceededError (detect by name === 'QuotaExceededError' or DOMException code 22) returning { ok: false, error: 'quota_exceeded' }; on success return { ok: true }. loadFromStorage should read storage.getItem(key); if null return { ok: false, error: 'missing' }; otherwise call deserializeSave and surface its result — on success { ok: true, state }, on malformed JSON or codec failure { ok: false, error: 'malformed' }. Define and export the typed result unions (SaveStorageResult, LoadStorageResult) with literal error tags. Add tests/sim/saveStorage.test.ts using an in-memory fake Storage class implementing getItem/setItem/removeItem (and length/key/clear stubs as needed) covering: (a) round-trip save then load returns the original SaveState, (b) loadFromStorage on a missing key returns { ok: false, error: 'missing' }, (c) loadFromStorage on a key whose value is malformed JSON or invalid save shape returns { ok: false, error: 'malformed' }, (d) saveToStorage when setItem throws a simulated QuotaExceededError returns { ok: false, error: 'quota_exceeded' }. Do not modify src/sim/save.ts or any simulation files.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*