### PR TITLE
feature: Add HUD save status indicator in src/hud/saveStatus.ts

### DIFF
--- a/src/hud/saveStatus.ts
+++ b/src/hud/saveStatus.ts
@@ -1,0 +1,36 @@
+export type SaveStatusState = "idle" | "saving" | "saved" | "error";
+
+export interface SaveStatusIndicator {
+  element: HTMLElement;
+  setStatus: (state: SaveStatusState, detail?: string) => void;
+}
+
+const statusLabels: Record<SaveStatusState, string> = {
+  idle: "Idle",
+  saving: "Saving...",
+  saved: "Saved",
+  error: "Error"
+};
+
+function formatStatusText(state: SaveStatusState, detail?: string): string {
+  const label = statusLabels[state];
+
+  return detail === undefined || detail.length === 0 ? label : `${label}: ${detail}`;
+}
+
+export function createSaveStatus(): SaveStatusIndicator {
+  const element = document.createElement("div");
+  element.dataset.testid = "hud-save-status";
+
+  function setStatus(state: SaveStatusState, detail?: string): void {
+    element.dataset.state = state;
+    element.textContent = formatStatusText(state, detail);
+  }
+
+  setStatus("idle");
+
+  return {
+    element,
+    setStatus
+  };
+}

--- a/tests/hud/saveStatus.test.ts
+++ b/tests/hud/saveStatus.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { createSaveStatus, type SaveStatusState } from "../../src/hud/saveStatus";
+
+const transitions: Array<[SaveStatusState, string]> = [
+  ["idle", "Idle"],
+  ["saving", "Saving..."],
+  ["saved", "Saved"],
+  ["error", "Error"]
+];
+
+describe("save status HUD", () => {
+  it("returns an element with the stable test selector", () => {
+    const saveStatus = createSaveStatus();
+
+    expect(saveStatus.element.dataset.testid).toBe("hud-save-status");
+  });
+
+  it("starts in the idle state", () => {
+    const saveStatus = createSaveStatus();
+
+    expect(saveStatus.element.dataset.state).toBe("idle");
+    expect(saveStatus.element.textContent).toBe("Idle");
+  });
+
+  it("updates data-state and text across deterministic transitions", () => {
+    const saveStatus = createSaveStatus();
+
+    for (const [state, label] of transitions) {
+      saveStatus.setStatus(state);
+
+      expect(saveStatus.element.dataset.state).toBe(state);
+      expect(saveStatus.element.textContent).toBe(label);
+    }
+  });
+
+  it("surfaces error details in visible text", () => {
+    const saveStatus = createSaveStatus();
+
+    saveStatus.setStatus("error", "localStorage unavailable");
+
+    expect(saveStatus.element.dataset.state).toBe("error");
+    expect(saveStatus.element.textContent).toBe("Error: localStorage unavailable");
+  });
+
+  it("keeps repeated same-state updates idempotent", () => {
+    const saveStatus = createSaveStatus();
+
+    saveStatus.setStatus("saving");
+    const firstText = saveStatus.element.textContent;
+    const firstState = saveStatus.element.dataset.state;
+
+    saveStatus.setStatus("saving");
+
+    expect(saveStatus.element.dataset.state).toBe(firstState);
+    expect(saveStatus.element.textContent).toBe(firstText);
+  });
+});


### PR DESCRIPTION
## Add HUD save status indicator in src/hud/saveStatus.ts

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #196

### Changes
Create src/hud/saveStatus.ts that exports a factory (e.g. createSaveStatus()) returning an object with an `element: HTMLElement` carrying data-testid="hud-save-status" and a `setStatus(state, detail?)` method where state is one of 'idle' | 'saving' | 'saved' | 'error'. Calling setStatus must update a `data-state` attribute on the element to match the state and update the visible text content deterministically (e.g. 'Idle', 'Saving…', 'Saved', 'Error' — optionally appended with the detail string when provided). Keep the module pure-DOM: do NOT import localStorage, the saveStorage adapter, simulation modules, or Three.js. Add tests/hud/saveStatus.test.ts using Vitest + jsdom (the existing tests/hud/index.test.ts confirms jsdom works) that verifies: (1) the returned element has the stable data-testid selector, (2) initial state is 'idle' with appropriate data-state and text, (3) each transition idle→saving→saved→error updates both data-state and text deterministically, (4) passing a detail string surfaces it in the visible text for at least the 'error' state, (5) re-calling setStatus with the same state is idempotent. Do NOT modify src/hud/index.ts in this task — barrel wiring is handled separately.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*