### PR TITLE
feature: Add block drop registry in src/sim/blockDrops.ts

### DIFF
--- a/src/sim/blockDrops.ts
+++ b/src/sim/blockDrops.ts
@@ -1,0 +1,28 @@
+import { BlockId } from "./blocks";
+
+export interface BlockDrop {
+  readonly item: BlockId;
+  readonly count: number;
+}
+
+export const BLOCK_DROPS = {
+  [BlockId.AIR]: [],
+  [BlockId.GRASS]: [{ item: BlockId.DIRT, count: 1 }],
+  [BlockId.DIRT]: [{ item: BlockId.DIRT, count: 1 }],
+  [BlockId.STONE]: [{ item: BlockId.STONE, count: 1 }],
+  [BlockId.WOOD]: [{ item: BlockId.WOOD, count: 1 }],
+  [BlockId.PLANKS]: [{ item: BlockId.PLANKS, count: 1 }],
+  [BlockId.STICK]: [],
+  [BlockId.COAL]: [{ item: BlockId.COAL, count: 1 }],
+  [BlockId.TORCH]: [{ item: BlockId.TORCH, count: 1 }]
+} as const satisfies Readonly<Record<BlockId, ReadonlyArray<BlockDrop>>>;
+
+export function getBlockDrops(blockId: BlockId): ReadonlyArray<BlockDrop> {
+  const drops = BLOCK_DROPS[blockId];
+
+  if (drops === undefined) {
+    throw new Error(`Unknown block id: ${blockId}`);
+  }
+
+  return drops;
+}

--- a/tests/sim/blockDrops.test.ts
+++ b/tests/sim/blockDrops.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { BLOCK_DROPS, getBlockDrops } from "../../src/sim/blockDrops";
+import { BLOCK_REGISTRY, BlockId } from "../../src/sim/blocks";
+
+describe("block drop registry", () => {
+  it("has an explicit drop entry for every block id", () => {
+    const blockIds = Object.values(BlockId);
+
+    expect(Object.keys(BLOCK_DROPS)).toHaveLength(blockIds.length);
+
+    for (const id of blockIds) {
+      expect(BLOCK_DROPS[id]).toBeDefined();
+    }
+  });
+
+  it("returns empty drops for air and non-mineable blocks", () => {
+    for (const definition of Object.values(BLOCK_REGISTRY)) {
+      if (definition.id === BlockId.AIR || !definition.mineable) {
+        expect(getBlockDrops(definition.id)).toEqual([]);
+      }
+    }
+  });
+
+  it("returns expected drops for mineable blocks", () => {
+    expect(getBlockDrops(BlockId.GRASS)).toEqual([{ item: BlockId.DIRT, count: 1 }]);
+    expect(getBlockDrops(BlockId.DIRT)).toEqual([{ item: BlockId.DIRT, count: 1 }]);
+    expect(getBlockDrops(BlockId.STONE)).toEqual([{ item: BlockId.STONE, count: 1 }]);
+    expect(getBlockDrops(BlockId.WOOD)).toEqual([{ item: BlockId.WOOD, count: 1 }]);
+    expect(getBlockDrops(BlockId.PLANKS)).toEqual([{ item: BlockId.PLANKS, count: 1 }]);
+    expect(getBlockDrops(BlockId.COAL)).toEqual([{ item: BlockId.COAL, count: 1 }]);
+    expect(getBlockDrops(BlockId.TORCH)).toEqual([{ item: BlockId.TORCH, count: 1 }]);
+  });
+
+  it("returns stable registry references", () => {
+    for (const id of Object.values(BlockId)) {
+      expect(getBlockDrops(id)).toBe(BLOCK_DROPS[id]);
+      expect(getBlockDrops(id)).toBe(getBlockDrops(id));
+    }
+  });
+
+  it("throws for unknown numeric ids", () => {
+    expect(() => getBlockDrops(999 as BlockId)).toThrow("Unknown block id: 999");
+  });
+});


### PR DESCRIPTION
## Add block drop registry in src/sim/blockDrops.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #178

### Changes
Create src/sim/blockDrops.ts exporting a deterministic registry that maps each BlockId to the item drops produced when the block is mined. Inspect src/sim/items.ts to determine the correct ItemId values to drop (e.g., GRASS drops the dirt item, DIRT drops dirt, STONE drops stone or cobblestone per the item registry, WOOD drops the wood/log item, COAL drops coal, PLANKS drops planks, STICK drops stick, TORCH drops torch, AIR drops nothing). Export a `BlockDrop` type representing a single drop entry `{ item: ItemId; count: number }`, a `BLOCK_DROPS` registry keyed by BlockId whose values are ReadonlyArray<BlockDrop>, and a `getBlockDrops(blockId: BlockId): ReadonlyArray<BlockDrop>` function. AIR (and any non-mineable block) MUST return an empty array. The function MUST throw `Unknown block id: <id>` for ids outside BlockId, mirroring the convention in getBlockDefinition. The registry MUST contain an entry for EVERY value in BlockId. The registry must be the same object reference across calls (stable). Add tests/sim/blockDrops.test.ts that: (a) asserts every BlockId has a registry entry, (b) asserts AIR drops an empty array, (c) asserts each non-air mineable block drops exactly one expected ItemId with count 1 (use a per-block table in the test), (d) asserts getBlockDrops returns the same array reference on repeated calls (registry stability), (e) asserts getBlockDrops throws for unknown numeric ids. Do NOT modify any existing files; the registry is a new, isolated module.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*