### PR TITLE
feature: Add HUD hotbar DOM component in src/hud/hotbar.ts

### DIFF
--- a/src/hud/hotbar.ts
+++ b/src/hud/hotbar.ts
@@ -1,0 +1,40 @@
+import type { Hotbar } from "../sim/hotbar";
+import type { Inventory } from "../sim/inventory";
+
+export interface HotbarRenderState {
+  readonly hotbar: Hotbar;
+  readonly inventory: Inventory;
+}
+
+export function createHotbarElement(state: HotbarRenderState): HTMLElement {
+  const root = document.createElement("div");
+
+  root.dataset.testid = "hud-hotbar";
+
+  return updateHotbarElement(root, state);
+}
+
+export function updateHotbarElement(root: HTMLElement, state: HotbarRenderState): HTMLElement {
+  root.dataset.testid = "hud-hotbar";
+
+  const slots = Array.from({ length: state.hotbar.size }, (_, index) => {
+    const slotElement = document.createElement("div");
+    const slot = state.inventory.slots[index] ?? null;
+
+    slotElement.dataset.testid = `hud-hotbar-slot-${index}`;
+
+    if (slot !== null) {
+      slotElement.dataset.itemId = String(slot.id);
+    }
+
+    if (index === state.hotbar.selected) {
+      slotElement.dataset.selected = "true";
+    }
+
+    return slotElement;
+  });
+
+  root.replaceChildren(...slots);
+
+  return root;
+}

--- a/tests/hud/hotbar.test.ts
+++ b/tests/hud/hotbar.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createHotbarElement, updateHotbarElement, type HotbarRenderState } from "../../src/hud/hotbar";
+import { BlockId } from "../../src/sim/blocks";
+import type { Hotbar } from "../../src/sim/hotbar";
+import type { Inventory } from "../../src/sim/inventory";
+
+function makeState(hotbar: Hotbar, slots: Inventory["slots"]): HotbarRenderState {
+  return {
+    hotbar,
+    inventory: {
+      slots,
+      selectedHotbarSlot: hotbar.selected
+    }
+  };
+}
+
+function getSlot(root: HTMLElement, index: number): HTMLElement {
+  const slot = root.querySelector<HTMLElement>(`[data-testid="hud-hotbar-slot-${index}"]`);
+
+  if (slot === null) {
+    throw new Error(`Missing hotbar slot ${index}.`);
+  }
+
+  return slot;
+}
+
+describe("hud hotbar", () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("renders one child per slot with stable selectors and item ids", () => {
+    const root = createHotbarElement(
+      makeState({ size: 3, selected: 1 }, [
+        { id: BlockId.DIRT, count: 8 },
+        null,
+        { id: BlockId.STONE, count: 2 }
+      ])
+    );
+
+    expect(root.dataset.testid).toBe("hud-hotbar");
+    expect(root.children).toHaveLength(3);
+    expect(getSlot(root, 0).dataset.itemId).toBe(String(BlockId.DIRT));
+    expect(getSlot(root, 1).dataset.itemId).toBeUndefined();
+    expect(getSlot(root, 2).dataset.itemId).toBe(String(BlockId.STONE));
+  });
+
+  it("marks only the selected slot with data-selected", () => {
+    const root = createHotbarElement(
+      makeState({ size: 4, selected: 2 }, [
+        { id: BlockId.DIRT, count: 1 },
+        { id: BlockId.GRASS, count: 1 },
+        { id: BlockId.WOOD, count: 1 },
+        null
+      ])
+    );
+
+    expect(getSlot(root, 0).dataset.selected).toBeUndefined();
+    expect(getSlot(root, 1).dataset.selected).toBeUndefined();
+    expect(getSlot(root, 2).dataset.selected).toBe("true");
+    expect(getSlot(root, 3).dataset.selected).toBeUndefined();
+  });
+
+  it("updates the same root when selection and item ids change", () => {
+    const root = createHotbarElement(
+      makeState({ size: 3, selected: 0 }, [
+        { id: BlockId.DIRT, count: 8 },
+        null,
+        { id: BlockId.STONE, count: 2 }
+      ])
+    );
+
+    const updatedRoot = updateHotbarElement(
+      root,
+      makeState({ size: 3, selected: 2 }, [
+        null,
+        { id: BlockId.WOOD, count: 1 },
+        { id: BlockId.GRASS, count: 5 }
+      ])
+    );
+
+    expect(updatedRoot).toBe(root);
+    expect(getSlot(root, 0).dataset.itemId).toBeUndefined();
+    expect(getSlot(root, 0).dataset.selected).toBeUndefined();
+    expect(getSlot(root, 1).dataset.itemId).toBe(String(BlockId.WOOD));
+    expect(getSlot(root, 1).dataset.selected).toBeUndefined();
+    expect(getSlot(root, 2).dataset.itemId).toBe(String(BlockId.GRASS));
+    expect(getSlot(root, 2).dataset.selected).toBe("true");
+  });
+
+  it("exposes documented selectors through document and element queries", () => {
+    const root = createHotbarElement(
+      makeState({ size: 2, selected: 1 }, [
+        { id: BlockId.TORCH, count: 3 },
+        { id: BlockId.COAL, count: 4 }
+      ])
+    );
+
+    document.body.append(root);
+
+    expect(document.querySelector('[data-testid="hud-hotbar"]')).toBe(root);
+    expect(root.querySelector('[data-testid="hud-hotbar-slot-0"]')).toBe(getSlot(root, 0));
+    expect(root.querySelector('[data-testid="hud-hotbar-slot-1"]')).toBe(getSlot(root, 1));
+    expect(getSlot(root, 1).dataset.itemId).toBe(String(BlockId.COAL));
+  });
+});


### PR DESCRIPTION
## Add HUD hotbar DOM component in src/hud/hotbar.ts

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #197

### Changes
Create src/hud/hotbar.ts exporting a function (e.g. createHotbarElement / renderHotbar) that builds a DOM element representing the hotbar. The root element must carry data-testid="hud-hotbar". For each slot it should append a child element with data-testid="hud-hotbar-slot-{index}" (0-based), include the contained block/item id as a stable data attribute (e.g. data-item-id), and mark the currently selected slot via data-selected="true" (other slots either omit the attribute or set it to "false"). The component must accept the simulation hotbar/inventory state (see src/sim/hotbar.ts and src/sim/inventory.ts) so callers can re-render or update selection deterministically without coupling to Three.js. Provide a way to update the rendered DOM when state changes (e.g. an update(state) function returning/mutating the same root). Add tests/hud/hotbar.test.ts using Vitest with jsdom-style DOM assertions: (a) initial render produces one child per slot with the correct data-testid and item id, (b) the selected slot has data-selected="true" and others do not, (c) updating state changes which slot is selected and which item ids appear, (d) selectors are queryable via document/element querySelector with the documented data-testid values. Do not modify src/hud/index.ts in this task — barrel wiring is a separate follow-up.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*