### PR TITLE
feature: Add block drop registry in src/sim/blockDrops.ts

### DIFF
--- a/src/sim/blockDrops.ts
+++ b/src/sim/blockDrops.ts
@@ -1,0 +1,30 @@
+import { BlockId } from "./blocks";
+
+export interface BlockDrop {
+  readonly item: BlockId;
+  readonly count: number;
+}
+
+const EMPTY_DROPS: ReadonlyArray<BlockDrop> = [];
+
+export const BLOCK_DROPS = {
+  [BlockId.AIR]: EMPTY_DROPS,
+  [BlockId.GRASS]: [{ item: BlockId.DIRT, count: 1 }],
+  [BlockId.DIRT]: [{ item: BlockId.DIRT, count: 1 }],
+  [BlockId.STONE]: [{ item: BlockId.STONE, count: 1 }],
+  [BlockId.WOOD]: [{ item: BlockId.WOOD, count: 1 }],
+  [BlockId.PLANKS]: [{ item: BlockId.PLANKS, count: 1 }],
+  [BlockId.STICK]: EMPTY_DROPS,
+  [BlockId.COAL]: [{ item: BlockId.COAL, count: 1 }],
+  [BlockId.TORCH]: [{ item: BlockId.TORCH, count: 1 }]
+} as const satisfies Readonly<Record<BlockId, ReadonlyArray<BlockDrop>>>;
+
+export function getBlockDrops(blockId: BlockId): ReadonlyArray<BlockDrop> {
+  const drops = BLOCK_DROPS[blockId];
+
+  if (drops === undefined) {
+    throw new Error(`Unknown block id: ${blockId}`);
+  }
+
+  return drops;
+}

--- a/tests/sim/blockDrops.test.ts
+++ b/tests/sim/blockDrops.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { BLOCK_DROPS, getBlockDrops, type BlockDrop } from "../../src/sim/blockDrops";
+import { BLOCK_REGISTRY, BlockId } from "../../src/sim/blocks";
+
+describe("block drop registry", () => {
+  it("has a registry entry for every block id", () => {
+    const blockIds = Object.values(BlockId);
+
+    expect(Object.keys(BLOCK_DROPS)).toHaveLength(blockIds.length);
+
+    for (const id of blockIds) {
+      expect(BLOCK_DROPS[id]).toBeDefined();
+    }
+  });
+
+  it("returns empty drops for air and non-mineable blocks", () => {
+    const nonMineableBlockIds = Object.values(BlockId).filter((id) => !BLOCK_REGISTRY[id].mineable);
+
+    expect(nonMineableBlockIds).toContain(BlockId.AIR);
+
+    for (const id of nonMineableBlockIds) {
+      expect(getBlockDrops(id)).toEqual([]);
+    }
+  });
+
+  it("returns expected mineable block drops", () => {
+    const expectedDrops: ReadonlyArray<readonly [BlockId, ReadonlyArray<BlockDrop>]> = [
+      [BlockId.GRASS, [{ item: BlockId.DIRT, count: 1 }]],
+      [BlockId.DIRT, [{ item: BlockId.DIRT, count: 1 }]],
+      [BlockId.STONE, [{ item: BlockId.STONE, count: 1 }]],
+      [BlockId.WOOD, [{ item: BlockId.WOOD, count: 1 }]],
+      [BlockId.PLANKS, [{ item: BlockId.PLANKS, count: 1 }]],
+      [BlockId.COAL, [{ item: BlockId.COAL, count: 1 }]],
+      [BlockId.TORCH, [{ item: BlockId.TORCH, count: 1 }]]
+    ];
+
+    for (const [id, drops] of expectedDrops) {
+      expect(getBlockDrops(id)).toEqual(drops);
+    }
+  });
+
+  it("returns stable registry references", () => {
+    for (const id of Object.values(BlockId)) {
+      const drops = getBlockDrops(id);
+
+      expect(drops).toBe(BLOCK_DROPS[id]);
+      expect(getBlockDrops(id)).toBe(drops);
+    }
+  });
+
+  it("throws for unknown numeric ids", () => {
+    expect(() => getBlockDrops(999 as BlockId)).toThrow("Unknown block id: 999");
+  });
+});


### PR DESCRIPTION
## Add block drop registry in src/sim/blockDrops.ts

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #178

### Changes
Create src/sim/blockDrops.ts exporting a deterministic registry that maps each BlockId to the inventory drops produced when the block is mined. Use the current inventory model: src/sim/inventory.ts stores item ids as BlockId, so this task must not return ItemId values. Export a BlockDrop type representing a single drop entry { item: BlockId; count: number }, a BLOCK_DROPS registry keyed by BlockId whose values are ReadonlyArray<BlockDrop>, and a getBlockDrops(blockId: BlockId): ReadonlyArray<BlockDrop> function. The registry must contain an explicit entry for every BlockId. AIR and non-mineable blocks must return an empty array. For mineable blocks, use the current block-as-inventory-id convention: GRASS drops DIRT; DIRT drops DIRT; STONE drops STONE; WOOD drops WOOD; PLANKS drops PLANKS; COAL drops COAL; TORCH drops TORCH. The function must throw Unknown block id: <id> for ids outside BlockId, matching getBlockDefinition. Returned arrays must be stable references from the registry. Add tests/sim/blockDrops.test.ts covering every BlockId, empty drops for AIR/non-mineable blocks, expected mineable BlockId drops, stable references, and unknown-id errors. Do not modify existing files.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*