### PR TITLE
feature: Add HUD inventory panel in src/hud/inventoryPanel.ts

### DIFF
--- a/src/hud/inventoryPanel.ts
+++ b/src/hud/inventoryPanel.ts
@@ -1,0 +1,33 @@
+import { getBlockDefinition } from "../sim/blocks";
+import type { Inventory, InventorySlot } from "../sim/inventory";
+
+export interface InventoryPanel {
+  readonly element: HTMLElement;
+  update(snapshot: Inventory): void;
+}
+
+function createItemRow(slot: InventorySlot): HTMLElement {
+  const row = document.createElement("div");
+  const definition = getBlockDefinition(slot.id);
+
+  row.dataset.itemId = String(slot.id);
+  row.dataset.itemCount = String(slot.count);
+  row.textContent = `${definition.name}: ${slot.count}`;
+
+  return row;
+}
+
+export function createInventoryPanel(): InventoryPanel {
+  const element = document.createElement("div");
+  element.dataset.testid = "inventory-panel";
+
+  return {
+    element,
+    update(snapshot) {
+      // Empty slots are omitted so only real inventory items carry item data attributes.
+      const rows = snapshot.slots.flatMap((slot) => (slot === null ? [] : [createItemRow(slot)]));
+
+      element.replaceChildren(...rows);
+    }
+  };
+}

--- a/tests/hud/inventoryPanel.test.ts
+++ b/tests/hud/inventoryPanel.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createInventoryPanel } from "../../src/hud/inventoryPanel";
+import { BlockId } from "../../src/sim/blocks";
+import type { Inventory } from "../../src/sim/inventory";
+
+function makeInventory(slots: Inventory["slots"]): Inventory {
+  return {
+    slots,
+    selectedHotbarSlot: 0
+  };
+}
+
+function readRenderedItems(): Array<{ id: string; count: string }> {
+  const root = document.querySelector<HTMLElement>('[data-testid="inventory-panel"]');
+
+  if (root === null) {
+    throw new Error("Inventory panel was not rendered");
+  }
+
+  return Array.from(root.querySelectorAll<HTMLElement>("[data-item-id]"), (row) => ({
+    id: row.dataset.itemId ?? "",
+    count: row.dataset.itemCount ?? ""
+  }));
+}
+
+describe("inventory panel", () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("renders an initial snapshot with stacked items", () => {
+    const panel = createInventoryPanel();
+    document.body.append(panel.element);
+
+    panel.update(
+      makeInventory([
+        { id: BlockId.DIRT, count: 12 },
+        null,
+        { id: BlockId.STONE, count: 64 },
+        { id: BlockId.WOOD, count: 3 }
+      ])
+    );
+
+    expect(readRenderedItems()).toEqual([
+      { id: String(BlockId.DIRT), count: "12" },
+      { id: String(BlockId.STONE), count: "64" },
+      { id: String(BlockId.WOOD), count: "3" }
+    ]);
+  });
+
+  it("updates rows when items are added, removed, or count-changed", () => {
+    const panel = createInventoryPanel();
+    document.body.append(panel.element);
+
+    panel.update(
+      makeInventory([
+        { id: BlockId.DIRT, count: 12 },
+        { id: BlockId.STONE, count: 64 },
+        { id: BlockId.WOOD, count: 3 }
+      ])
+    );
+
+    panel.update(
+      makeInventory([
+        { id: BlockId.DIRT, count: 9 },
+        null,
+        { id: BlockId.TORCH, count: 5 }
+      ])
+    );
+
+    expect(readRenderedItems()).toEqual([
+      { id: String(BlockId.DIRT), count: "9" },
+      { id: String(BlockId.TORCH), count: "5" }
+    ]);
+  });
+
+  it("does not render item rows for empty slots", () => {
+    const panel = createInventoryPanel();
+    document.body.append(panel.element);
+
+    panel.update(makeInventory([null, null, { id: BlockId.COAL, count: 2 }, null]));
+
+    expect(readRenderedItems()).toEqual([{ id: String(BlockId.COAL), count: "2" }]);
+  });
+});


### PR DESCRIPTION
## Add HUD inventory panel in src/hud/inventoryPanel.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #201

### Changes
Create src/hud/inventoryPanel.ts that builds and updates a DOM element rendering the contents of an inventory snapshot. Read the existing Inventory shape from src/sim/inventory.ts (slots are an array where each entry is null or { id, count }) and the BlockId enum from src/sim/blocks.ts so the panel can label rows by block id. Export a factory like `createInventoryPanel()` that returns an object exposing `element: HTMLElement` and `update(snapshot: Inventory): void`. The root element must carry data-testid="inventory-panel". Each non-null slot must render as a child element carrying data-item-id (the block/item id, e.g. the BlockId numeric or string key — pick one and stay consistent) and data-item-count (the integer count as a string). Empty slots may be omitted or rendered without those attributes; document the chosen behavior in code. Calling update again with a new snapshot must reconcile so subsequent rows reflect the new state (added, removed, or count-changed items) without leaking stale rows. Add tests/hud/inventoryPanel.test.ts that uses Vitest with happy-dom/jsdom (whatever vitest.config.ts already configures — do not change the env) to: (a) render an initial snapshot with several stacked items and assert the rendered rows match by querying [data-testid="inventory-panel"] and reading data-item-id / data-item-count; (b) call update with a snapshot that adds a new item, removes one, and changes a count, then assert the DOM reflects the new state; (c) verify empty/null slots do not produce phantom item rows. Do NOT modify src/hud/index.ts — leave the commented export alone to avoid conflicting with sibling HUD tasks; tests import the panel directly from its module path.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*