### PR TITLE
feature: Add world chunk-mesh manager in src/render/worldRenderer.ts

### DIFF
--- a/src/render/worldRenderer.ts
+++ b/src/render/worldRenderer.ts
@@ -1,0 +1,126 @@
+import * as THREE from "three";
+
+import { CHUNK_SIZE, type Chunk } from "../sim/chunk";
+import type { ChunkKey, World } from "../sim/world";
+import { buildChunkMesh } from "./chunkMesh";
+
+type ChunkMesh = THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+
+export interface WorldRenderer {
+  sync(): void;
+  dispose(): void;
+}
+
+export function createWorldRenderer(scene: THREE.Scene, world: World): WorldRenderer {
+  const material = new THREE.MeshStandardMaterial();
+  const meshes = new Map<ChunkKey, ChunkMesh>();
+  const chunkHashes = new Map<ChunkKey, number>();
+  let disposed = false;
+
+  function sync(): void {
+    if (disposed) {
+      return;
+    }
+
+    const liveKeys = new Set<ChunkKey>();
+
+    for (const [key, chunk] of Object.entries(world)) {
+      if (chunk === undefined) {
+        continue;
+      }
+
+      const chunkKey = key as ChunkKey;
+      const chunkHash = hashChunk(chunk);
+
+      liveKeys.add(chunkKey);
+
+      if (chunkHashes.get(chunkKey) === chunkHash && meshes.has(chunkKey)) {
+        continue;
+      }
+
+      rebuildChunkMesh(chunkKey, chunk, chunkHash);
+    }
+
+    for (const [key, mesh] of meshes) {
+      if (liveKeys.has(key)) {
+        continue;
+      }
+
+      scene.remove(mesh);
+      mesh.geometry.dispose();
+      meshes.delete(key);
+      chunkHashes.delete(key);
+    }
+  }
+
+  function dispose(): void {
+    if (disposed) {
+      return;
+    }
+
+    disposed = true;
+
+    for (const mesh of meshes.values()) {
+      scene.remove(mesh);
+      mesh.geometry.dispose();
+    }
+
+    meshes.clear();
+    chunkHashes.clear();
+    material.dispose();
+  }
+
+  function rebuildChunkMesh(key: ChunkKey, chunk: Chunk, chunkHash: number): void {
+    const geometry = buildChunkMesh(chunk);
+    const mesh = meshes.get(key);
+
+    if (mesh === undefined) {
+      const nextMesh = new THREE.Mesh(geometry, material);
+
+      positionChunkMesh(nextMesh, key);
+      meshes.set(key, nextMesh);
+      scene.add(nextMesh);
+    } else {
+      mesh.geometry.dispose();
+      mesh.geometry = geometry;
+    }
+
+    chunkHashes.set(key, chunkHash);
+  }
+
+  return {
+    sync,
+    dispose
+  };
+}
+
+function positionChunkMesh(mesh: ChunkMesh, key: ChunkKey): void {
+  const [chunkX, chunkY, chunkZ] = parseChunkKey(key);
+
+  mesh.position.set(
+    chunkX * CHUNK_SIZE,
+    chunkY * CHUNK_SIZE,
+    chunkZ * CHUNK_SIZE
+  );
+}
+
+function parseChunkKey(key: ChunkKey): readonly [number, number, number] {
+  const [chunkXText, chunkYText, chunkZText] = key.split(",");
+
+  if (chunkXText === undefined || chunkYText === undefined || chunkZText === undefined) {
+    throw new Error(`Invalid chunk key: ${key}`);
+  }
+
+  return [Number(chunkXText), Number(chunkYText), Number(chunkZText)];
+}
+
+function hashChunk(chunk: Chunk): number {
+  let hash = 2166136261;
+
+  for (const blockId of chunk.blocks) {
+    hash ^= blockId;
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}

--- a/tests/render/worldRenderer.test.ts
+++ b/tests/render/worldRenderer.test.ts
@@ -1,0 +1,132 @@
+import * as THREE from "three";
+import { describe, expect, it, vi } from "vitest";
+
+import { createWorldRenderer } from "../../src/render/worldRenderer";
+import { BlockId } from "../../src/sim/blocks";
+import { CHUNK_SIZE } from "../../src/sim/chunk";
+import { createWorld, setBlock, type ChunkKey, type World } from "../../src/sim/world";
+
+describe("createWorldRenderer", () => {
+  it("adds one positioned mesh for every loaded chunk", () => {
+    const scene = new THREE.Scene();
+    const world = createSeededWorld();
+    const renderer = createWorldRenderer(scene, world);
+
+    renderer.sync();
+
+    const keys = getChunkKeys(world);
+    const meshes = getSceneMeshes(scene);
+
+    expect(meshes).toHaveLength(keys.length);
+
+    for (const key of keys) {
+      const mesh = getMeshForChunk(scene, key);
+
+      expect(mesh.position.toArray()).toEqual(getChunkOrigin(key));
+      expect(scene.children).toContain(mesh);
+    }
+
+    renderer.dispose();
+  });
+
+  it("rebuilds only the mutated chunk mesh geometry", () => {
+    const scene = new THREE.Scene();
+    const world = createSeededWorld();
+    const renderer = createWorldRenderer(scene, world);
+
+    renderer.sync();
+
+    const dirtyKey: ChunkKey = "0,0,0";
+    const stableKey: ChunkKey = "1,0,0";
+    const dirtyMesh = getMeshForChunk(scene, dirtyKey);
+    const stableMesh = getMeshForChunk(scene, stableKey);
+    const dirtyGeometry = dirtyMesh.geometry;
+    const stableGeometry = stableMesh.geometry;
+    const dirtyGeometryDispose = vi.spyOn(dirtyGeometry, "dispose");
+
+    setBlock(world, 2, 2, 3, BlockId.DIRT);
+    renderer.sync();
+
+    expect(getMeshForChunk(scene, dirtyKey)).toBe(dirtyMesh);
+    expect(dirtyMesh.geometry).not.toBe(dirtyGeometry);
+    expect(dirtyGeometryDispose).toHaveBeenCalledTimes(1);
+    expect(getMeshForChunk(scene, stableKey)).toBe(stableMesh);
+    expect(stableMesh.geometry).toBe(stableGeometry);
+
+    renderer.dispose();
+  });
+
+  it("removes evicted chunk meshes and disposes their geometry", () => {
+    const scene = new THREE.Scene();
+    const world = createSeededWorld();
+    const renderer = createWorldRenderer(scene, world);
+
+    renderer.sync();
+
+    const evictedKey: ChunkKey = "1,0,0";
+    const evictedMesh = getMeshForChunk(scene, evictedKey);
+    const evictedGeometryDispose = vi.spyOn(evictedMesh.geometry, "dispose");
+
+    delete world[evictedKey];
+    renderer.sync();
+
+    expect(scene.children).not.toContain(evictedMesh);
+    expect(getSceneMeshes(scene)).toHaveLength(getChunkKeys(world).length);
+    expect(evictedGeometryDispose).toHaveBeenCalledTimes(1);
+
+    renderer.dispose();
+  });
+});
+
+function createSeededWorld(): World {
+  const world = createWorld();
+
+  setBlock(world, 1, 2, 3, BlockId.STONE);
+  setBlock(world, CHUNK_SIZE + 1, 2, 3, BlockId.DIRT);
+  setBlock(world, -1, 1, 0, BlockId.GRASS);
+
+  return world;
+}
+
+function getChunkKeys(world: World): ChunkKey[] {
+  return (Object.keys(world) as ChunkKey[]).sort();
+}
+
+function getMeshForChunk(scene: THREE.Scene, key: ChunkKey): THREE.Mesh {
+  const origin = getChunkOrigin(key);
+  const mesh = getSceneMeshes(scene).find((candidate) => {
+    return candidate.position.toArray().every((coordinate, index) => coordinate === origin[index]);
+  });
+
+  expect(mesh).toBeDefined();
+
+  if (mesh === undefined) {
+    throw new Error(`Missing mesh for chunk ${key}`);
+  }
+
+  return mesh;
+}
+
+function getSceneMeshes(scene: THREE.Scene): THREE.Mesh[] {
+  return scene.children.filter((child): child is THREE.Mesh => child instanceof THREE.Mesh);
+}
+
+function getChunkOrigin(key: ChunkKey): readonly [number, number, number] {
+  const [chunkX, chunkY, chunkZ] = parseChunkKey(key);
+
+  return [
+    chunkX * CHUNK_SIZE,
+    chunkY * CHUNK_SIZE,
+    chunkZ * CHUNK_SIZE
+  ];
+}
+
+function parseChunkKey(key: ChunkKey): readonly [number, number, number] {
+  const [chunkXText, chunkYText, chunkZText] = key.split(",");
+
+  if (chunkXText === undefined || chunkYText === undefined || chunkZText === undefined) {
+    throw new Error(`Invalid chunk key: ${key}`);
+  }
+
+  return [Number(chunkXText), Number(chunkYText), Number(chunkZText)];
+}


### PR DESCRIPTION
## Add world chunk-mesh manager in src/render/worldRenderer.ts

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #200

### Changes
Create src/render/worldRenderer.ts that exports createWorldRenderer(scene, world) returning an object with a sync() method (and optionally dispose()). Internally it owns a Map<ChunkKey, THREE.Mesh> keyed by the World's chunk key (matching the existing keying convention in src/sim/world.ts). On sync(): for each chunk currently in world, if no mesh exists yet OR the chunk is marked dirty per the World's existing dirty-tracking API, build a fresh BufferGeometry via buildChunkMesh from src/render/chunkMesh.ts, wrap it in a THREE.Mesh positioned at the chunk's world-space origin (chunkCoord * CHUNK_SIZE), add it to the scene, and replace any prior mesh (disposing the old geometry/material). For chunks whose key is in the map but no longer present in world, remove the mesh from the scene, dispose, and delete the map entry. Clear the dirty flags after rebuilding (using whatever World API already exists for that). Use a single shared MeshStandardMaterial (vertexColors or default) so rebuilds only swap geometry. Read src/sim/world.ts first to discover the exact dirty-tracking API and chunk key format before implementing — do not invent new World APIs; if the World does not yet expose dirty tracking, fall back to a content-hash or revision counter you read off each chunk, but prefer the existing mechanism. Add tests/render/worldRenderer.test.ts using a real THREE.Scene and a seeded World: (1) after sync, every loaded chunk has a corresponding mesh added to scene.children with correct position; (2) mutating a block via the World's setBlock + sync() replaces the prior mesh object (or its geometry) for that chunk and leaves untouched chunks' mesh references stable; (3) removing a chunk from world (eviction) followed by sync() removes the mesh from the scene and disposes its geometry. Keep the renderer pure of simulation logic — it only reads from World and writes to scene.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*