### PR TITLE
feature: Add deterministic auto-save scheduler in src/sim/autoSave.ts

### DIFF
--- a/src/sim/autoSave.ts
+++ b/src/sim/autoSave.ts
@@ -1,0 +1,95 @@
+import type { SaveStatusState } from "../hud/saveStatus";
+import type { SaveState } from "./save";
+import type { SaveStorageResult } from "./saveStorage";
+
+const DEFAULT_DIRTY_TICK_THRESHOLD = 60;
+
+export interface AutoSaveStatus {
+  state: SaveStatusState;
+  lastSavedAt: number | null;
+  detail?: string;
+}
+
+export interface AutoSaver {
+  markDirty: () => void;
+  tick: (snapshot: SaveState) => void;
+  getStatus: () => AutoSaveStatus;
+  forceSave: (snapshot: SaveState) => void;
+}
+
+export interface AutoSaverOptions {
+  intervalMs: number;
+  now: () => number;
+  save: (snapshot: SaveState) => SaveStorageResult;
+  dirtyTickThreshold?: number;
+}
+
+export function createAutoSaver({
+  intervalMs,
+  now,
+  save,
+  dirtyTickThreshold = DEFAULT_DIRTY_TICK_THRESHOLD
+}: AutoSaverOptions): AutoSaver {
+  const startedAt = now();
+  let dirty = false;
+  let dirtyTicks = 0;
+  let state: SaveStatusState = "idle";
+  let lastSavedAt: number | null = null;
+  let detail: string | undefined;
+
+  function getStatus(): AutoSaveStatus {
+    return detail === undefined
+      ? { state, lastSavedAt }
+      : { state, lastSavedAt, detail };
+  }
+
+  function flush(snapshot: SaveState, savedAt: number): void {
+    state = "saving";
+    detail = undefined;
+
+    const result = save(snapshot);
+
+    if (result.ok) {
+      dirty = false;
+      dirtyTicks = 0;
+      lastSavedAt = savedAt;
+      state = "saved";
+      return;
+    }
+
+    state = "error";
+    detail = result.error;
+  }
+
+  function markDirty(): void {
+    dirty = true;
+  }
+
+  function tick(snapshot: SaveState): void {
+    if (!dirty) {
+      return;
+    }
+
+    dirtyTicks += 1;
+
+    const currentTime = now();
+    const lastGateAt = lastSavedAt ?? startedAt;
+    const shouldSave =
+      currentTime - lastGateAt >= intervalMs || dirtyTicks >= dirtyTickThreshold;
+
+    if (shouldSave) {
+      flush(snapshot, currentTime);
+    }
+  }
+
+  function forceSave(snapshot: SaveState): void {
+    flush(snapshot, now());
+  }
+
+  return {
+    markDirty,
+    tick,
+    getStatus,
+    forceSave
+  };
+}

--- a/tests/sim/autoSave.test.ts
+++ b/tests/sim/autoSave.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import { createAutoSaver } from "../../src/sim/autoSave";
+import { SAVE_VERSION, type SaveState } from "../../src/sim/save";
+import type { SaveStorageResult } from "../../src/sim/saveStorage";
+
+const snapshot: SaveState = {
+  version: SAVE_VERSION,
+  seed: 12345,
+  mutations: [
+    { x: 1, y: 2, z: 3, block: BlockId.DIRT }
+  ],
+  player: {
+    position: [4, 5, 6],
+    orientation: {
+      yaw: 0.5,
+      pitch: -0.25
+    }
+  },
+  inventory: {
+    slots: [
+      { block: BlockId.GRASS, count: 4 },
+      null
+    ]
+  },
+  hotbar: {
+    selected: 0
+  }
+};
+
+function createClock(start = 0): {
+  now: () => number;
+  advance: (ms: number) => void;
+  set: (value: number) => void;
+} {
+  let current = start;
+
+  return {
+    now: () => current,
+    advance: (ms: number) => {
+      current += ms;
+    },
+    set: (value: number) => {
+      current = value;
+    }
+  };
+}
+
+describe("auto-save scheduler", () => {
+  it("does not save on tick when state is not dirty", () => {
+    const clock = createClock();
+    let saveCount = 0;
+    const autoSaver = createAutoSaver({
+      intervalMs: 1000,
+      now: clock.now,
+      save: () => {
+        saveCount += 1;
+        return { ok: true };
+      }
+    });
+
+    clock.advance(1000);
+    autoSaver.tick(snapshot);
+
+    expect(saveCount).toBe(0);
+    expect(autoSaver.getStatus()).toEqual({ state: "idle", lastSavedAt: null });
+  });
+
+  it("flushes dirty state after intervalMs elapses", () => {
+    const clock = createClock();
+    let saveCount = 0;
+    const autoSaver = createAutoSaver({
+      intervalMs: 1000,
+      now: clock.now,
+      save: () => {
+        saveCount += 1;
+        return { ok: true };
+      }
+    });
+
+    autoSaver.markDirty();
+    autoSaver.tick(snapshot);
+    clock.advance(999);
+    autoSaver.tick(snapshot);
+    clock.advance(1);
+    autoSaver.tick(snapshot);
+
+    expect(saveCount).toBe(1);
+    expect(autoSaver.getStatus()).toEqual({ state: "saved", lastSavedAt: 1000 });
+  });
+
+  it("flushes after dirtyTickThreshold ticks even before intervalMs elapses", () => {
+    const clock = createClock();
+    let saveCount = 0;
+    const autoSaver = createAutoSaver({
+      intervalMs: 1000,
+      dirtyTickThreshold: 3,
+      now: clock.now,
+      save: () => {
+        saveCount += 1;
+        return { ok: true };
+      }
+    });
+
+    autoSaver.markDirty();
+    autoSaver.tick(snapshot);
+    autoSaver.tick(snapshot);
+    autoSaver.tick(snapshot);
+
+    expect(saveCount).toBe(1);
+    expect(autoSaver.getStatus()).toEqual({ state: "saved", lastSavedAt: 0 });
+  });
+
+  it("exposes saving during synchronous successful saves before settling as saved", () => {
+    const clock = createClock();
+    const observedStates: Array<string> = [];
+    let autoSaver: ReturnType<typeof createAutoSaver> | null = null;
+
+    autoSaver = createAutoSaver({
+      intervalMs: 0,
+      now: clock.now,
+      save: () => {
+        if (autoSaver === null) {
+          throw new Error("autoSaver was not initialized");
+        }
+
+        observedStates.push(autoSaver.getStatus().state);
+        return { ok: true };
+      }
+    });
+
+    expect(autoSaver.getStatus()).toEqual({ state: "idle", lastSavedAt: null });
+
+    autoSaver.markDirty();
+    autoSaver.tick(snapshot);
+
+    expect(observedStates).toEqual(["saving"]);
+    expect(autoSaver.getStatus()).toEqual({ state: "saved", lastSavedAt: 0 });
+  });
+
+  it("sets error status detail from quota_exceeded storage failures", () => {
+    const clock = createClock();
+    const autoSaver = createAutoSaver({
+      intervalMs: 0,
+      now: clock.now,
+      save: () => ({ ok: false, error: "quota_exceeded" })
+    });
+
+    autoSaver.markDirty();
+    autoSaver.tick(snapshot);
+
+    expect(autoSaver.getStatus()).toEqual({
+      state: "error",
+      lastSavedAt: null,
+      detail: "quota_exceeded"
+    });
+  });
+
+  it("advances lastSavedAt only after successful saves", () => {
+    const clock = createClock(10);
+    const results: Array<SaveStorageResult> = [
+      { ok: true },
+      { ok: false, error: "quota_exceeded" },
+      { ok: true }
+    ];
+    const autoSaver = createAutoSaver({
+      intervalMs: 5,
+      now: clock.now,
+      save: () => results.shift() ?? { ok: true }
+    });
+
+    autoSaver.forceSave(snapshot);
+    expect(autoSaver.getStatus()).toEqual({ state: "saved", lastSavedAt: 10 });
+
+    clock.set(20);
+    autoSaver.markDirty();
+    autoSaver.tick(snapshot);
+    expect(autoSaver.getStatus()).toEqual({
+      state: "error",
+      lastSavedAt: 10,
+      detail: "quota_exceeded"
+    });
+
+    clock.set(30);
+    autoSaver.tick(snapshot);
+    expect(autoSaver.getStatus()).toEqual({ state: "saved", lastSavedAt: 30 });
+  });
+
+  it("forceSave bypasses interval and dirty tick gates", () => {
+    const clock = createClock();
+    let saveCount = 0;
+    const autoSaver = createAutoSaver({
+      intervalMs: 1000,
+      dirtyTickThreshold: 10,
+      now: clock.now,
+      save: () => {
+        saveCount += 1;
+        return { ok: true };
+      }
+    });
+
+    autoSaver.forceSave(snapshot);
+
+    expect(saveCount).toBe(1);
+    expect(autoSaver.getStatus()).toEqual({ state: "saved", lastSavedAt: 0 });
+  });
+
+  it("gates repeated successful saves from the most recent save time", () => {
+    const clock = createClock();
+    let saveCount = 0;
+    const autoSaver = createAutoSaver({
+      intervalMs: 1000,
+      now: clock.now,
+      save: () => {
+        saveCount += 1;
+        return { ok: true };
+      }
+    });
+
+    autoSaver.markDirty();
+    clock.set(1000);
+    autoSaver.tick(snapshot);
+
+    autoSaver.markDirty();
+    clock.set(1500);
+    autoSaver.tick(snapshot);
+    clock.set(1999);
+    autoSaver.tick(snapshot);
+    clock.set(2000);
+    autoSaver.tick(snapshot);
+
+    expect(saveCount).toBe(2);
+    expect(autoSaver.getStatus()).toEqual({ state: "saved", lastSavedAt: 2000 });
+  });
+});


### PR DESCRIPTION
## Add deterministic auto-save scheduler in src/sim/autoSave.ts

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #217

### Changes
Create a pure, deterministic auto-save scheduler in src/sim/autoSave.ts plus matching unit tests in tests/sim/autoSave.test.ts. Export `createAutoSaver({ intervalMs, now, save, dirtyTickThreshold? })` where: `now: () => number` returns wall-clock-equivalent ms (injected for determinism, no `Date.now` calls inside the module), `save: (snapshot: SaveState) => SaveStorageResult` is the existing storage adapter result shape from src/sim/saveStorage.ts, `intervalMs` is the minimum elapsed time between flushes, and `dirtyTickThreshold` (optional, e.g. default 60) is the number of tick() calls with dirty state that force a flush sooner. The returned object should expose: `markDirty()` to record that a mutation occurred, `tick(snapshot: SaveState)` which decides whether to flush this tick (flushes when dirty AND (now - lastSavedAt >= intervalMs OR dirtyTicks >= dirtyTickThreshold)), `getStatus()` returning `{ state: 'idle' | 'saving' | 'saved' | 'error', lastSavedAt: number | null, detail?: string }` matching the SaveStatusState union from src/hud/saveStatus.ts, and `forceSave(snapshot)` for explicit flushes. tick should call save() synchronously, transition state through saving → saved on `{ ok: true }` and saving → error with `detail` set from the storage error tag (e.g. 'quota_exceeded') on `{ ok: false }`. Reset dirtyTicks and update lastSavedAt only on a successful save. The module must contain NO DOM access, NO setInterval/setTimeout, and NO direct Date usage — all timing flows through the injected `now`. Tests must cover: no-op tick when not dirty; flush after intervalMs elapses; flush after dirtyTickThreshold ticks even before intervalMs; status transitions idle → saving → saved on success; status transitions to error with detail on quota_exceeded result; lastSavedAt advances only on success; forceSave bypasses interval/threshold gates; repeated successful saves continue to gate by intervalMs from the most recent save.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*