### PR TITLE
feature: Add mine/place action resolver in src/sim/actions.ts

### DIFF
--- a/src/sim/actions.ts
+++ b/src/sim/actions.ts
@@ -1,0 +1,107 @@
+import { BlockId, getBlockDefinition } from "./blocks";
+import { CHUNK_SIZE } from "./chunk";
+import { addItem, removeItem, type Inventory } from "./inventory";
+import type { ItemId } from "./items";
+import { getBlock, setBlock, type ChunkKey, type World } from "./world";
+
+export interface VoxelCoord {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+export interface Hit {
+  readonly target: VoxelCoord;
+  readonly normal: VoxelCoord;
+}
+
+export interface BlockDrop {
+  readonly itemId: BlockId | ItemId;
+  readonly count: number;
+}
+
+export type BlockDrops = Readonly<Partial<Record<BlockId, BlockDrop>>>;
+
+export interface ActionResolveResult {
+  readonly ok: boolean;
+  readonly world: World;
+  readonly inventory: Inventory;
+}
+
+export function resolveMine(
+  world: World,
+  hit: Hit,
+  inventory: Inventory,
+  drops: BlockDrops
+): ActionResolveResult {
+  const blockId = getBlock(world, hit.target.x, hit.target.y, hit.target.z);
+  const definition = getBlockDefinition(blockId);
+
+  if (blockId === BlockId.AIR || !definition.mineable) {
+    return { ok: false, world, inventory };
+  }
+
+  const nextWorld = cloneWorldForWrite(world, hit.target);
+  setBlock(nextWorld, hit.target.x, hit.target.y, hit.target.z, BlockId.AIR);
+
+  const drop = drops[blockId];
+  const nextInventory =
+    drop === undefined ? inventory : addItem(inventory, drop.itemId as BlockId, drop.count).inventory;
+
+  return { ok: true, world: nextWorld, inventory: nextInventory };
+}
+
+export function resolvePlace(
+  world: World,
+  hit: Hit,
+  inventory: Inventory,
+  blockId: BlockId
+): ActionResolveResult {
+  if (blockId === BlockId.AIR) {
+    return { ok: false, world, inventory };
+  }
+
+  const target = {
+    x: hit.target.x + hit.normal.x,
+    y: hit.target.y + hit.normal.y,
+    z: hit.target.z + hit.normal.z
+  };
+
+  if (getBlock(world, target.x, target.y, target.z) !== BlockId.AIR) {
+    return { ok: false, world, inventory };
+  }
+
+  const removed = removeItem(inventory, blockId, 1);
+
+  if (removed.removed !== 1) {
+    return { ok: false, world, inventory };
+  }
+
+  const nextWorld = cloneWorldForWrite(world, target);
+  setBlock(nextWorld, target.x, target.y, target.z, blockId);
+
+  return { ok: true, world: nextWorld, inventory: removed.inventory };
+}
+
+function cloneWorldForWrite(world: World, voxel: VoxelCoord): World {
+  const nextWorld: World = { ...world };
+  const key = chunkKeyForVoxel(voxel);
+  const chunk = world[key];
+
+  if (chunk !== undefined) {
+    nextWorld[key] = {
+      size: chunk.size,
+      blocks: new Uint8Array(chunk.blocks)
+    };
+  }
+
+  return nextWorld;
+}
+
+function chunkKeyForVoxel(voxel: VoxelCoord): ChunkKey {
+  return `${chunkCoordinate(voxel.x)},${chunkCoordinate(voxel.y)},${chunkCoordinate(voxel.z)}`;
+}
+
+function chunkCoordinate(coordinate: number): number {
+  return Math.floor(coordinate / CHUNK_SIZE);
+}

--- a/tests/sim/actions.test.ts
+++ b/tests/sim/actions.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import { resolveMine, resolvePlace, type BlockDrop, type BlockDrops, type Hit } from "../../src/sim/actions";
+import { type Inventory } from "../../src/sim/inventory";
+import { createWorld, getBlock, setBlock, type ChunkKey, type World } from "../../src/sim/world";
+
+const originHit: Hit = {
+  target: { x: 1, y: 2, z: 3 },
+  normal: { x: 0, y: 0, z: 1 }
+};
+
+const drops = {
+  [BlockId.STONE]: { itemId: BlockId.DIRT, count: 2 },
+  [BlockId.WOOD]: { itemId: BlockId.WOOD, count: 1 }
+} satisfies BlockDrops;
+
+describe("action resolvers", () => {
+  it("mines a mineable block into air and adds the mapped drop without mutating inputs", () => {
+    const world = createWorld();
+    const inventory = makeInventory([null]);
+    setBlock(world, originHit.target.x, originHit.target.y, originHit.target.z, BlockId.STONE);
+    const worldSnapshot = cloneWorld(world);
+    const inventorySnapshot = cloneInventory(inventory);
+    const hitSnapshot = cloneHit(originHit);
+    const dropsSnapshot = cloneDrops(drops);
+
+    const result = resolveMine(world, originHit, inventory, drops);
+
+    expect(result.ok).toBe(true);
+    expect(result.world).not.toBe(world);
+    expect(result.inventory).not.toBe(inventory);
+    expect(getBlock(result.world, originHit.target.x, originHit.target.y, originHit.target.z)).toBe(BlockId.AIR);
+    expect(result.inventory.slots).toEqual([{ id: BlockId.DIRT, count: 2 }]);
+    expect(result.world["0,0,0" as ChunkKey]).not.toBe(world["0,0,0" as ChunkKey]);
+    expect(world).toEqual(worldSnapshot);
+    expect(inventory).toEqual(inventorySnapshot);
+    expect(originHit).toEqual(hitSnapshot);
+    expect(drops).toEqual(dropsSnapshot);
+  });
+
+  it("returns ok false for mining air with inputs unchanged", () => {
+    const world = createWorld();
+    const inventory = makeInventory([null]);
+    const worldSnapshot = cloneWorld(world);
+    const inventorySnapshot = cloneInventory(inventory);
+
+    const result = resolveMine(world, originHit, inventory, drops);
+
+    expect(result).toEqual({ ok: false, world, inventory });
+    expect(result.world).toBe(world);
+    expect(result.inventory).toBe(inventory);
+    expect(world).toEqual(worldSnapshot);
+    expect(inventory).toEqual(inventorySnapshot);
+  });
+
+  it("returns ok false for mining a non-mineable block with inputs unchanged", () => {
+    const world = createWorld();
+    const inventory = makeInventory([null]);
+    setBlock(world, originHit.target.x, originHit.target.y, originHit.target.z, BlockId.STICK);
+    const worldSnapshot = cloneWorld(world);
+    const inventorySnapshot = cloneInventory(inventory);
+
+    const result = resolveMine(world, originHit, inventory, drops);
+
+    expect(result).toEqual({ ok: false, world, inventory });
+    expect(getBlock(world, originHit.target.x, originHit.target.y, originHit.target.z)).toBe(BlockId.STICK);
+    expect(world).toEqual(worldSnapshot);
+    expect(inventory).toEqual(inventorySnapshot);
+  });
+
+  it("places into the adjacent air cell and consumes exactly one matching item without mutating inputs", () => {
+    const world = createWorld();
+    const inventory = makeInventory([{ id: BlockId.DIRT, count: 2 }]);
+    setBlock(world, originHit.target.x, originHit.target.y, originHit.target.z, BlockId.STONE);
+    const worldSnapshot = cloneWorld(world);
+    const inventorySnapshot = cloneInventory(inventory);
+    const hitSnapshot = cloneHit(originHit);
+
+    const result = resolvePlace(world, originHit, inventory, BlockId.DIRT);
+
+    expect(result.ok).toBe(true);
+    expect(result.world).not.toBe(world);
+    expect(result.inventory).not.toBe(inventory);
+    expect(getBlock(result.world, originHit.target.x, originHit.target.y, originHit.target.z)).toBe(BlockId.STONE);
+    expect(getBlock(result.world, 1, 2, 4)).toBe(BlockId.DIRT);
+    expect(result.inventory.slots).toEqual([{ id: BlockId.DIRT, count: 1 }]);
+    expect(world).toEqual(worldSnapshot);
+    expect(inventory).toEqual(inventorySnapshot);
+    expect(originHit).toEqual(hitSnapshot);
+  });
+
+  it("returns ok false when placement adjacent cell is non-air", () => {
+    const world = createWorld();
+    const inventory = makeInventory([{ id: BlockId.DIRT, count: 1 }]);
+    setBlock(world, originHit.target.x, originHit.target.y, originHit.target.z, BlockId.STONE);
+    setBlock(world, 1, 2, 4, BlockId.WOOD);
+    const worldSnapshot = cloneWorld(world);
+    const inventorySnapshot = cloneInventory(inventory);
+
+    const result = resolvePlace(world, originHit, inventory, BlockId.DIRT);
+
+    expect(result).toEqual({ ok: false, world, inventory });
+    expect(result.world).toBe(world);
+    expect(result.inventory).toBe(inventory);
+    expect(world).toEqual(worldSnapshot);
+    expect(inventory).toEqual(inventorySnapshot);
+  });
+
+  it("returns ok false when inventory lacks the block being placed", () => {
+    const world = createWorld();
+    const inventory = makeInventory([null]);
+    setBlock(world, originHit.target.x, originHit.target.y, originHit.target.z, BlockId.STONE);
+    const worldSnapshot = cloneWorld(world);
+    const inventorySnapshot = cloneInventory(inventory);
+
+    const result = resolvePlace(world, originHit, inventory, BlockId.DIRT);
+
+    expect(result).toEqual({ ok: false, world, inventory });
+    expect(getBlock(world, 1, 2, 4)).toBe(BlockId.AIR);
+    expect(world).toEqual(worldSnapshot);
+    expect(inventory).toEqual(inventorySnapshot);
+  });
+});
+
+function makeInventory(slots: Inventory["slots"], selectedHotbarSlot = 0): Inventory {
+  return { slots, selectedHotbarSlot };
+}
+
+function cloneInventory(inventory: Inventory): Inventory {
+  return {
+    selectedHotbarSlot: inventory.selectedHotbarSlot,
+    slots: inventory.slots.map((slot) => (slot === null ? null : { id: slot.id, count: slot.count }))
+  };
+}
+
+function cloneHit(hit: Hit): Hit {
+  return {
+    target: { ...hit.target },
+    normal: { ...hit.normal }
+  };
+}
+
+function cloneDrops(blockDrops: BlockDrops): BlockDrops {
+  const clone: Partial<Record<BlockId, BlockDrop>> = {};
+
+  for (const blockId of Object.values(BlockId) as BlockId[]) {
+    const drop = blockDrops[blockId];
+
+    if (drop !== undefined) {
+      clone[blockId] = { itemId: drop.itemId, count: drop.count };
+    }
+  }
+
+  return clone;
+}
+
+function cloneWorld(world: World): World {
+  const clone: World = {};
+
+  for (const [key, chunk] of Object.entries(world)) {
+    if (chunk === undefined) {
+      continue;
+    }
+
+    clone[key as ChunkKey] = {
+      size: chunk.size,
+      blocks: new Uint8Array(chunk.blocks)
+    };
+  }
+
+  return clone;
+}


### PR DESCRIPTION
## Add mine/place action resolver in src/sim/actions.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #179

### Changes
Create src/sim/actions.ts that exports two pure functions: resolveMine(world, hit, inventory, drops) and resolvePlace(world, hit, inventory, blockId). The `hit` argument is a raycast hit shape with a target voxel coordinate {x,y,z} and a face normal {x,y,z} pointing from the hit cell toward the adjacent empty cell where placement should occur. The `drops` argument is a lookup of BlockId -> {itemId: ItemId|BlockId, count: number} the agent should accept as a parameter (do NOT import a not-yet-existing blockDrops module — keep it injected). Both functions must be PURE: do not mutate the passed-in world, inventory, hit, or drops. Return a result object describing the next-state delta, e.g. resolveMine returns { ok: boolean, world: World, inventory: Inventory } where world reflects the mined cell becoming AIR and inventory reflects the drop being added (using addItem from src/sim/inventory.ts); resolvePlace returns { ok: boolean, world: World, inventory: Inventory } where world reflects the new block written at hit.target + hit.normal and inventory reflects one item consumed (using removeItem). When mining a non-mineable block (AIR or block whose registry entry has mineable=false), return { ok: false, world, inventory } with the inputs unchanged. When placing into a non-air cell, or when the inventory has no matching item to consume, return { ok: false } with inputs unchanged. Use immutable updates: build a fresh World by cloning only the affected chunk's blocks (or rely on existing setBlock helper if it returns a new world; otherwise treat setBlock as mutating and clone the world structure first). Read src/sim/world.ts and src/sim/chunk.ts to choose the correct approach — if setBlock mutates, deep-clone the world's chunk map and the affected chunk before applying changes so the input world reference is untouched. Prefer importing existing types (World, Inventory, BlockId, ItemId, Hotbar) from their source modules; do not redefine them. Add tests/sim/actions.test.ts covering ALL of: (1) mining a solid mineable block sets the target cell to AIR in the returned world AND adds the mapped drop item to the returned inventory, while leaving the input world and inventory references unmodified; (2) mining AIR returns { ok: false } with inputs unchanged; (3) mining a non-mineable block (e.g. a block whose registry entry has mineable=false, if any exists; otherwise skip but document why) returns ok:false; (4) placing onto an existing solid block writes the new block at hit.target + hit.normal (the adjacent face cell) when that adjacent cell is AIR, AND consumes exactly one of the corresponding item from inventory; (5) placement fails with ok:false when the adjacent cell is non-AIR; (6) placement fails with ok:false when the inventory lacks the item; (7) input world and input inventory references are NOT mutated by either function (assert via deep equality against pre-call snapshots). Use a fixed in-memory drops map in tests rather than importing any registry.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*