### PR TITLE
feature: Add deterministic player look controller in src/sim/playerLook.ts

### DIFF
--- a/src/sim/playerLook.ts
+++ b/src/sim/playerLook.ts
@@ -1,0 +1,45 @@
+export interface PlayerLookPose {
+  readonly yaw: number;
+  readonly pitch: number;
+}
+
+export interface MouseLookDelta {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface ApplyLookDeltaOptions {
+  readonly pitchLimit?: number;
+}
+
+const FULL_TURN = Math.PI * 2;
+
+export const PITCH_LIMIT = Math.PI / 2 - Math.PI / 180;
+
+export function applyLookDelta(
+  pose: Readonly<PlayerLookPose>,
+  mouseDelta: Readonly<MouseLookDelta>,
+  sensitivity: number,
+  options: Readonly<ApplyLookDeltaOptions> = {}
+): PlayerLookPose {
+  const pitchLimit = options.pitchLimit ?? PITCH_LIMIT;
+
+  return {
+    yaw: wrapYaw(pose.yaw + mouseDelta.x * sensitivity),
+    pitch: clamp(pose.pitch + mouseDelta.y * sensitivity, -pitchLimit, pitchLimit)
+  };
+}
+
+function wrapYaw(yaw: number): number {
+  if (yaw >= -Math.PI && yaw <= Math.PI) {
+    return yaw;
+  }
+
+  const wrapped = ((((yaw + Math.PI) % FULL_TURN) + FULL_TURN) % FULL_TURN) - Math.PI;
+
+  return wrapped === -Math.PI && yaw > Math.PI ? Math.PI : wrapped;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/tests/sim/playerLook.test.ts
+++ b/tests/sim/playerLook.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyLookDelta,
+  PITCH_LIMIT,
+  type PlayerLookPose
+} from "../../src/sim/playerLook";
+
+describe("player look controller", () => {
+  it("wraps yaw from just below pi across the positive boundary", () => {
+    const next = applyLookDelta({ yaw: Math.PI - 0.01, pitch: 0 }, { x: 0.02, y: 0 }, 1);
+
+    expect(next.yaw).toBeGreaterThanOrEqual(-Math.PI);
+    expect(next.yaw).toBeLessThanOrEqual(Math.PI);
+    expect(next.yaw).toBeCloseTo(-Math.PI + 0.01);
+  });
+
+  it("wraps yaw symmetrically across the negative boundary", () => {
+    const next = applyLookDelta({ yaw: -Math.PI + 0.01, pitch: 0 }, { x: -0.02, y: 0 }, 1);
+
+    expect(next.yaw).toBeGreaterThanOrEqual(-Math.PI);
+    expect(next.yaw).toBeLessThanOrEqual(Math.PI);
+    expect(next.yaw).toBeCloseTo(Math.PI - 0.01);
+  });
+
+  it("clamps pitch to the positive limit", () => {
+    const next = applyLookDelta({ yaw: 0, pitch: PITCH_LIMIT - 0.01 }, { x: 0, y: 1 }, 1);
+
+    expect(next.pitch).toBe(PITCH_LIMIT);
+  });
+
+  it("clamps pitch to the negative limit", () => {
+    const next = applyLookDelta({ yaw: 0, pitch: -PITCH_LIMIT + 0.01 }, { x: 0, y: -1 }, 1);
+
+    expect(next.pitch).toBe(-PITCH_LIMIT);
+  });
+
+  it("scales yaw and pitch deltas linearly with sensitivity", () => {
+    const next = applyLookDelta({ yaw: 0.1, pitch: -0.2 }, { x: 0.2, y: -0.1 }, 2);
+
+    expect(next.yaw).toBeCloseTo(0.5);
+    expect(next.pitch).toBeCloseTo(-0.4);
+  });
+
+  it("allows callers to override the pitch limit", () => {
+    const next = applyLookDelta({ yaw: 0, pitch: 0 }, { x: 0, y: 1 }, 1, { pitchLimit: 0.5 });
+
+    expect(next.pitch).toBe(0.5);
+  });
+
+  it("returns an equal new pose for zero mouse delta without mutating input", () => {
+    const pose: PlayerLookPose = { yaw: 0.75, pitch: -0.25 };
+    const snapshot = { ...pose };
+    const next = applyLookDelta(pose, { x: 0, y: 0 }, 4);
+
+    expect(next).toEqual(pose);
+    expect(next).not.toBe(pose);
+    expect(pose).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
## Add deterministic player look controller in src/sim/playerLook.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #222

### Changes
Create src/sim/playerLook.ts exporting an applyLookDelta(pose, mouseDelta, sensitivity) helper plus any small supporting types/constants. The function takes a pose containing { yaw, pitch } (numbers, in radians), a mouseDelta { x, y } from a look intent, and a sensitivity scalar; it returns a NEW pose object (does not mutate input) with: yaw = wrap(pose.yaw + mouseDelta.x * sensitivity) into [-PI, PI], and pitch = clamp(pose.pitch + mouseDelta.y * sensitivity) within a configurable max range just shy of straight-up/straight-down. Export a PITCH_LIMIT constant (e.g. PI/2 - small epsilon, ~1.5533 rad / ~89 degrees) used for clamping; allow callers to override the limit via an optional 4th argument or options bag if natural. Be deterministic: identical inputs must produce identical outputs, no randomness, no time-based behavior. Add tests/sim/playerLook.test.ts covering: (1) yaw wraps from just below PI across the boundary to a value in [-PI, PI] when delta pushes it past +PI; (2) yaw wraps symmetrically when delta pushes below -PI; (3) pitch clamps to +PITCH_LIMIT when a large positive delta would exceed it; (4) pitch clamps to -PITCH_LIMIT when a large negative delta would go below it; (5) sensitivity scales both yaw and pitch deltas linearly (e.g. sensitivity 2 doubles the applied delta); (6) a zero mouseDelta returns a pose equal in value to the input (no-op) and does not mutate the input pose. Keep the module pure and free of DOM/Three.js imports.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*