### PR TITLE
feature: Add player movement kinematics in src/sim/playerKinematics.ts

### DIFF
--- a/src/sim/playerKinematics.ts
+++ b/src/sim/playerKinematics.ts
@@ -1,0 +1,72 @@
+import { resolveCollision, type AABB, type BlockGetter } from "./collision";
+import { type Player, type Vec3 } from "./player";
+
+export interface KinematicsIntent {
+  readonly forward: number;
+  readonly strafe: number;
+  readonly jump: boolean;
+}
+
+const PLAYER_HALF_WIDTH = 0.3;
+const PLAYER_HEIGHT = 1.8;
+const WALK_SPEED = 4;
+const JUMP_IMPULSE = 5;
+const GROUND_PROBE_DISTANCE = 0.01;
+
+export function stepPlayer(
+  player: Readonly<Player>,
+  intent: Readonly<KinematicsIntent>,
+  gravity: number,
+  dt: number,
+  getBlock: BlockGetter
+): Player {
+  const fixedDt = Number.isFinite(dt) ? Math.max(0, dt) : 0;
+  const grounded = isGrounded(player, getBlock);
+  const horizontal = rotateHorizontalIntent(player.yaw, intent.forward, intent.strafe);
+  const velocity: Vec3 = [
+    horizontal[0] * WALK_SPEED,
+    grounded && intent.jump ? JUMP_IMPULSE : player.velocity[1],
+    horizontal[1] * WALK_SPEED
+  ];
+
+  velocity[1] += gravity * fixedDt;
+
+  const collision = resolveCollision(
+    playerAabb(player.position),
+    [velocity[0] * fixedDt, velocity[1] * fixedDt, velocity[2] * fixedDt],
+    getBlock
+  );
+
+  return {
+    ...player,
+    position: [
+      player.position[0] + collision.delta[0],
+      player.position[1] + collision.delta[1],
+      player.position[2] + collision.delta[2]
+    ],
+    velocity: [
+      collision.contacts.x ? 0 : velocity[0],
+      collision.contacts.y ? 0 : velocity[1],
+      collision.contacts.z ? 0 : velocity[2]
+    ]
+  };
+}
+
+function isGrounded(player: Readonly<Player>, getBlock: BlockGetter): boolean {
+  return resolveCollision(playerAabb(player.position), [0, -GROUND_PROBE_DISTANCE, 0], getBlock).grounded;
+}
+
+function rotateHorizontalIntent(yaw: number, forward: number, strafe: number): readonly [number, number] {
+  const x = Math.sin(yaw) * forward + Math.cos(yaw) * strafe;
+  const z = Math.cos(yaw) * forward - Math.sin(yaw) * strafe;
+  const length = Math.hypot(x, z);
+
+  return length > 1 ? [x / length, z / length] : [x, z];
+}
+
+function playerAabb(position: Readonly<Vec3>): AABB {
+  return {
+    min: [position[0] - PLAYER_HALF_WIDTH, position[1], position[2] - PLAYER_HALF_WIDTH],
+    max: [position[0] + PLAYER_HALF_WIDTH, position[1] + PLAYER_HEIGHT, position[2] + PLAYER_HALF_WIDTH]
+  };
+}

--- a/tests/sim/playerKinematics.test.ts
+++ b/tests/sim/playerKinematics.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import { type BlockGetter } from "../../src/sim/collision";
+import { createPlayer, type Player, type Vec3 } from "../../src/sim/player";
+import { stepPlayer, type KinematicsIntent } from "../../src/sim/playerKinematics";
+
+const GROUNDED_Y = 1.0001;
+const GRAVITY = -10;
+
+const NEUTRAL_INTENT: KinematicsIntent = {
+  forward: 0,
+  strafe: 0,
+  jump: false
+};
+
+describe("stepPlayer", () => {
+  it("walks forward on flat solid ground and stays able to jump", () => {
+    const player = makePlayer({
+      position: [0.5, GROUNDED_Y, 0.5],
+      velocity: [0, 0, 0],
+      yaw: 0
+    });
+    const next = stepPlayer(player, { ...NEUTRAL_INTENT, forward: 1 }, GRAVITY, 0.1, ground());
+
+    expect(next.position[0]).toBeCloseTo(0.5);
+    expect(next.position[1]).toBeCloseTo(GROUNDED_Y);
+    expect(next.position[2]).toBeGreaterThan(player.position[2]);
+    expect(next.velocity[1]).toBe(0);
+
+    const jump = stepPlayer(next, { ...NEUTRAL_INTENT, jump: true }, GRAVITY, 0.1, ground());
+
+    expect(jump.velocity[1]).toBeGreaterThan(0);
+  });
+
+  it("zeroes blocked-axis velocity when walking into a wall", () => {
+    const player = makePlayer({
+      position: [0.5, GROUNDED_Y, 0.5],
+      velocity: [0, 0, 0],
+      yaw: 0
+    });
+    const next = stepPlayer(
+      player,
+      { ...NEUTRAL_INTENT, forward: 1 },
+      GRAVITY,
+      0.5,
+      groundWithBlocks([
+        [0, 1, 1],
+        [0, 2, 1]
+      ])
+    );
+
+    expect(next.position[2]).toBeCloseTo(0.7);
+    expect(next.velocity[2]).toBe(0);
+    expect(next.velocity[1]).toBe(0);
+  });
+
+  it("lands on top of a solid block and zeroes vertical velocity", () => {
+    const player = makePlayer({
+      position: [0.5, 2, 0.5],
+      velocity: [0, -4, 0]
+    });
+    const next = stepPlayer(player, NEUTRAL_INTENT, 0, 1, ground());
+
+    expect(next.position[1]).toBeCloseTo(GROUNDED_Y);
+    expect(next.velocity[1]).toBe(0);
+
+    const jump = stepPlayer(next, { ...NEUTRAL_INTENT, jump: true }, 0, 0, ground());
+
+    expect(jump.velocity[1]).toBeGreaterThan(0);
+  });
+
+  it("only applies jump impulse while grounded at the start of the tick", () => {
+    const grounded = makePlayer({
+      position: [0.5, GROUNDED_Y, 0.5],
+      velocity: [0, 0, 0]
+    });
+    const airborne = makePlayer({
+      position: [0.5, 2, 0.5],
+      velocity: [0, 0, 0]
+    });
+
+    expect(
+      stepPlayer(grounded, { ...NEUTRAL_INTENT, jump: true }, GRAVITY, 0.1, ground()).velocity[1]
+    ).toBeGreaterThan(0);
+    expect(
+      stepPlayer(airborne, { ...NEUTRAL_INTENT, jump: true }, GRAVITY, 0.1, ground()).velocity[1]
+    ).toBeLessThanOrEqual(0);
+  });
+
+  it("does not mutate the input player or vector arrays", () => {
+    const player = makePlayer({
+      position: [0.5, GROUNDED_Y, 0.5],
+      velocity: [1, 2, 3],
+      yaw: Math.PI / 2
+    });
+    const snapshot: Player = {
+      ...player,
+      position: [...player.position],
+      velocity: [...player.velocity]
+    };
+    const next = stepPlayer(player, { ...NEUTRAL_INTENT, strafe: 1 }, GRAVITY, 0.1, ground());
+
+    expect(player).toEqual(snapshot);
+    expect(next).not.toBe(player);
+    expect(next.position).not.toBe(player.position);
+    expect(next.velocity).not.toBe(player.velocity);
+  });
+});
+
+function makePlayer(overrides: Partial<Player>): Player {
+  const player = createPlayer();
+
+  return {
+    ...player,
+    ...overrides,
+    position: overrides.position === undefined ? [...player.position] : [...overrides.position],
+    velocity: overrides.velocity === undefined ? [...player.velocity] : [...overrides.velocity]
+  };
+}
+
+function ground(): BlockGetter {
+  return (...cell: Vec3) => (cell[1] === 0 ? BlockId.STONE : BlockId.AIR);
+}
+
+function groundWithBlocks(cells: readonly Vec3[]): BlockGetter {
+  const solidCells = new Map(cells.map((cell) => [key(cell[0], cell[1], cell[2]), BlockId.STONE]));
+  const groundBlock = ground();
+
+  return (x: number, y: number, z: number) => solidCells.get(key(x, y, z)) ?? groundBlock(x, y, z);
+}
+
+function key(x: number, y: number, z: number): string {
+  return `${x},${y},${z}`;
+}


### PR DESCRIPTION
## Add player movement kinematics in src/sim/playerKinematics.ts

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #223

### Changes
Create src/sim/playerKinematics.ts exporting a pure `stepPlayer` function that takes the current Player pose (position, velocity, yaw — read the actual Player shape from src/sim/player.ts), a movement intent shape with forward/strafe/jump fields (you may define a local KinematicsIntent interface; do not change src/input/intents.ts), a gravity scalar, a delta-time scalar, a `BlockGetter` from src/sim/collision.ts (or equivalent block-lookup function), and returns the next Player pose. The function must: (1) rotate the (forward, strafe) horizontal intent into world space using the player's yaw and apply it as horizontal acceleration or velocity per frame, (2) add gravity to vertical velocity each tick, (3) only apply a jump impulse when the player is grounded (use the `grounded` contact result from a prior collision resolve to gate jumping), (4) feed the proposed delta into resolveCollision from src/sim/collision.ts using a player AABB and zero out velocity components on axes where collision contacts occurred, (5) be pure — never mutate the input Player or its arrays. Add tests/sim/playerKinematics.test.ts with cases: (a) walking forward on flat solid ground produces horizontal displacement and stays grounded, (b) walking into a wall of solid blocks zeroes the blocked-axis velocity and leaves the player at the wall, (c) starting above a solid block with downward velocity lands on top of the block with vertical velocity zeroed and grounded=true, (d) a jump intent while grounded produces upward velocity, while a jump intent while airborne does NOT add upward velocity. Use the existing BlockId registry to define a tiny BlockGetter for tests (returning STONE for ground cells, AIR otherwise). Keep the module focused on kinematics — no rendering or input parsing.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*