### PR TITLE
feature: Add COAL_ORE block and drop/render mappings in src/sim/blocks.ts

### DIFF
--- a/src/render/chunkMesh.ts
+++ b/src/render/chunkMesh.ts
@@ -34,7 +34,8 @@ const BLOCK_FACE_UVS = {
   [BlockId.PLANKS]: DEFAULT_FACE_UV,
   [BlockId.STICK]: DEFAULT_FACE_UV,
   [BlockId.COAL]: DEFAULT_FACE_UV,
-  [BlockId.TORCH]: DEFAULT_FACE_UV
+  [BlockId.TORCH]: DEFAULT_FACE_UV,
+  [BlockId.COAL_ORE]: DEFAULT_FACE_UV
 } as const satisfies Readonly<Record<BlockId, BlockFaceUV>>;
 
 const FACE_DEFINITIONS: readonly FaceDefinition[] = [

--- a/src/sim/blockDrops.ts
+++ b/src/sim/blockDrops.ts
@@ -16,7 +16,8 @@ export const BLOCK_DROPS = {
   [BlockId.PLANKS]: [{ item: BlockId.PLANKS, count: 1 }],
   [BlockId.STICK]: EMPTY_DROPS,
   [BlockId.COAL]: [{ item: BlockId.COAL, count: 1 }],
-  [BlockId.TORCH]: [{ item: BlockId.TORCH, count: 1 }]
+  [BlockId.TORCH]: [{ item: BlockId.TORCH, count: 1 }],
+  [BlockId.COAL_ORE]: [{ item: BlockId.COAL, count: 1 }]
 } as const satisfies Readonly<Record<BlockId, ReadonlyArray<BlockDrop>>>;
 
 export function getBlockDrops(blockId: BlockId): ReadonlyArray<BlockDrop> {

--- a/src/sim/blocks.ts
+++ b/src/sim/blocks.ts
@@ -7,7 +7,8 @@ export const BlockId = {
   PLANKS: 5,
   STICK: 6,
   COAL: 7,
-  TORCH: 8
+  TORCH: 8,
+  COAL_ORE: 9
 } as const;
 
 export type BlockId = (typeof BlockId)[keyof typeof BlockId];
@@ -72,6 +73,12 @@ export const BLOCK_REGISTRY = {
     id: BlockId.TORCH,
     name: "Torch",
     solid: false,
+    mineable: true
+  },
+  [BlockId.COAL_ORE]: {
+    id: BlockId.COAL_ORE,
+    name: "Coal Ore",
+    solid: true,
     mineable: true
   }
 } as const satisfies Readonly<Record<BlockId, BlockDefinition>>;

--- a/tests/render/chunkMesh.test.ts
+++ b/tests/render/chunkMesh.test.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import { describe, expect, it } from "vitest";
 
-import { buildChunkMesh } from "../../src/render/chunkMesh";
+import { buildChunkMesh, getBlockFaceUV } from "../../src/render/chunkMesh";
 import { BlockId } from "../../src/sim/blocks";
 import { CHUNK_SIZE, createChunk, setBlock } from "../../src/sim/chunk";
 
@@ -23,6 +23,18 @@ describe("buildChunkMesh", () => {
     expect(getFaceCount(geometry)).toBe(6);
     expect(geometry.getIndex()?.count).toBe(36);
     expect(geometry.getAttribute("position").count).toBe(24);
+  });
+
+  it("emits faces and UVs for coal ore", () => {
+    const chunk = createChunk();
+
+    setBlock(chunk, 4, 5, 6, BlockId.COAL_ORE);
+
+    const geometry = buildChunkMesh(chunk);
+
+    expect(getFaceCount(geometry)).toBe(6);
+    expect(getBlockFaceUV(BlockId.COAL_ORE)).toHaveLength(4);
+    expect(geometry.getAttribute("uv").count).toBe(24);
   });
 
   it("omits the internal face between adjacent solid blocks", () => {

--- a/tests/sim/blockDrops.test.ts
+++ b/tests/sim/blockDrops.test.ts
@@ -32,7 +32,8 @@ describe("block drop registry", () => {
       [BlockId.WOOD, [{ item: BlockId.WOOD, count: 1 }]],
       [BlockId.PLANKS, [{ item: BlockId.PLANKS, count: 1 }]],
       [BlockId.COAL, [{ item: BlockId.COAL, count: 1 }]],
-      [BlockId.TORCH, [{ item: BlockId.TORCH, count: 1 }]]
+      [BlockId.TORCH, [{ item: BlockId.TORCH, count: 1 }]],
+      [BlockId.COAL_ORE, [{ item: BlockId.COAL, count: 1 }]]
     ];
 
     for (const [id, drops] of expectedDrops) {

--- a/tests/sim/blocks.test.ts
+++ b/tests/sim/blocks.test.ts
@@ -3,6 +3,19 @@ import { describe, expect, it } from "vitest";
 import { BLOCK_REGISTRY, BlockId, getBlockDefinition } from "../../src/sim/blocks";
 
 describe("block registry", () => {
+  it("keeps existing block ids stable and appends coal ore", () => {
+    expect(BlockId.AIR).toBe(0);
+    expect(BlockId.GRASS).toBe(1);
+    expect(BlockId.DIRT).toBe(2);
+    expect(BlockId.STONE).toBe(3);
+    expect(BlockId.WOOD).toBe(4);
+    expect(BlockId.PLANKS).toBe(5);
+    expect(BlockId.STICK).toBe(6);
+    expect(BlockId.COAL).toBe(7);
+    expect(BlockId.TORCH).toBe(8);
+    expect(BlockId.COAL_ORE).toBe(9);
+  });
+
   it("has a registry entry for every block id", () => {
     const blockIds = Object.values(BlockId);
 
@@ -24,6 +37,11 @@ describe("block registry", () => {
     });
     expect(BLOCK_REGISTRY[BlockId.TORCH]).toMatchObject({
       solid: false,
+      mineable: true
+    });
+    expect(BLOCK_REGISTRY[BlockId.COAL_ORE]).toMatchObject({
+      name: "Coal Ore",
+      solid: true,
       mineable: true
     });
   });


### PR DESCRIPTION
## Add COAL_ORE block and drop/render mappings in src/sim/blocks.ts

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #238

### Changes
Add a distinct BlockId.COAL_ORE value to src/sim/blocks.ts for terrain ore generation. The new block definition must be named Coal Ore, solid: true, and mineable: true. Preserve the existing numeric values for all existing BlockId entries, including BlockId.COAL. Update tests/sim/blocks.test.ts to cover the new id and definition. Because blockDrops currently requires an explicit entry for every BlockId, update src/sim/blockDrops.ts and tests/sim/blockDrops.test.ts so COAL_ORE drops exactly one BlockId.COAL. Because render/chunkMesh has exhaustive block UV/color mappings keyed by BlockId, update src/render/chunkMesh.ts and tests/render/chunkMesh.test.ts so COAL_ORE renders without weakening the BlockId type. Do not change inventory APIs or ItemId semantics; the current inventory model stores BlockId values.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*