### PR TITLE
feature: Add deterministic craftAction resolver with typed failures

### DIFF
--- a/src/sim/craftAction.ts
+++ b/src/sim/craftAction.ts
@@ -1,0 +1,82 @@
+import { RECIPES, type Recipe, type RecipeOutput } from "./crafting";
+import { addItem, removeItem, type Inventory } from "./inventory";
+import type { BlockId } from "./blocks";
+import type { ItemId } from "./items";
+
+export type RecipeId = string;
+export type CraftFailureReason = "unknown_recipe" | "insufficient_inputs";
+export type MissingCraftInputs = Partial<Record<BlockId | ItemId, number>>;
+
+export type CraftActionResult =
+  | {
+      readonly ok: true;
+      readonly inventory: Inventory;
+      readonly output: RecipeOutput;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: "unknown_recipe";
+      readonly inventory: Inventory;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: "insufficient_inputs";
+      readonly inventory: Inventory;
+      readonly missing: MissingCraftInputs;
+    };
+
+function hasOwn<T extends object>(object: T, key: PropertyKey): key is keyof T {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function findRecipe(recipeId: RecipeId): Recipe | undefined {
+  return hasOwn(RECIPES, recipeId) ? RECIPES[recipeId] : undefined;
+}
+
+function countItem(inventory: Inventory, item: BlockId): number {
+  return inventory.slots.reduce((total, slot) => total + (slot?.id === item ? slot.count : 0), 0);
+}
+
+function missingInputs(inventory: Inventory, recipe: Recipe): MissingCraftInputs {
+  const missing: MissingCraftInputs = {};
+
+  for (const input of recipe.inputs) {
+    const shortfall = input.count - countItem(inventory, input.item);
+
+    if (shortfall > 0) {
+      missing[input.item] = shortfall;
+    }
+  }
+
+  return missing;
+}
+
+function hasMissingInputs(missing: MissingCraftInputs): boolean {
+  return Object.keys(missing).length > 0;
+}
+
+export function resolveCraft(inventory: Inventory, recipeId: RecipeId): CraftActionResult {
+  const recipe = findRecipe(recipeId);
+
+  if (recipe === undefined) {
+    return { ok: false, reason: "unknown_recipe", inventory };
+  }
+
+  const missing = missingInputs(inventory, recipe);
+
+  if (hasMissingInputs(missing)) {
+    return { ok: false, reason: "insufficient_inputs", inventory, missing };
+  }
+
+  let nextInventory = inventory;
+
+  for (const input of recipe.inputs) {
+    nextInventory = removeItem(nextInventory, input.item, input.count).inventory;
+  }
+
+  return {
+    ok: true,
+    inventory: addItem(nextInventory, recipe.output.item, recipe.output.count).inventory,
+    output: { item: recipe.output.item, count: recipe.output.count }
+  };
+}

--- a/tests/sim/craftAction.test.ts
+++ b/tests/sim/craftAction.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import { resolveCraft, type CraftActionResult } from "../../src/sim/craftAction";
+import { type Inventory } from "../../src/sim/inventory";
+
+function expectSuccess(result: CraftActionResult): asserts result is Extract<CraftActionResult, { ok: true }> {
+  expect(result.ok).toBe(true);
+}
+
+function makeInventory(slots: Inventory["slots"], selectedHotbarSlot = 0): Inventory {
+  return { slots, selectedHotbarSlot };
+}
+
+function cloneInventory(inventory: Inventory): Inventory {
+  return {
+    selectedHotbarSlot: inventory.selectedHotbarSlot,
+    slots: inventory.slots.map((slot) => (slot === null ? null : { id: slot.id, count: slot.count }))
+  };
+}
+
+describe("craft action resolver", () => {
+  it.each([
+    {
+      recipeId: "planks",
+      inventory: makeInventory([{ id: BlockId.WOOD, count: 1 }, null]),
+      expectedSlots: [{ id: BlockId.PLANKS, count: 4 }, null],
+      output: { item: BlockId.PLANKS, count: 4 }
+    },
+    {
+      recipeId: "sticks",
+      inventory: makeInventory([{ id: BlockId.PLANKS, count: 2 }, null]),
+      expectedSlots: [{ id: BlockId.STICK, count: 4 }, null],
+      output: { item: BlockId.STICK, count: 4 }
+    },
+    {
+      recipeId: "torch",
+      inventory: makeInventory([{ id: BlockId.STICK, count: 1 }, { id: BlockId.COAL, count: 1 }, null]),
+      expectedSlots: [{ id: BlockId.TORCH, count: 4 }, null, null],
+      output: { item: BlockId.TORCH, count: 4 }
+    }
+  ])("crafts $recipeId using the MVP recipe registry", ({ recipeId, inventory, expectedSlots, output }) => {
+    const result = resolveCraft(inventory, recipeId);
+
+    expectSuccess(result);
+    expect(result.inventory).not.toBe(inventory);
+    expect(result.inventory.slots).toEqual(expectedSlots);
+    expect(result.output).toEqual(output);
+  });
+
+  it("reports missing inputs with the original inventory reference untouched", () => {
+    const inventory = makeInventory([{ id: BlockId.STICK, count: 1 }, null]);
+    const snapshot = cloneInventory(inventory);
+    const result = resolveCraft(inventory, "torch");
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "insufficient_inputs",
+      inventory,
+      missing: { [BlockId.COAL]: 1 }
+    });
+    expect(result.inventory).toBe(inventory);
+    expect(inventory).toEqual(snapshot);
+  });
+
+  it("reports unknown recipes with the original inventory reference untouched", () => {
+    const inventory = makeInventory([{ id: BlockId.WOOD, count: 1 }]);
+    const snapshot = cloneInventory(inventory);
+    const result = resolveCraft(inventory, "missing");
+
+    expect(result).toEqual({ ok: false, reason: "unknown_recipe", inventory });
+    expect(result.inventory).toBe(inventory);
+    expect(inventory).toEqual(snapshot);
+  });
+
+  it("does not mutate the input inventory on a successful craft", () => {
+    const inventory = makeInventory([{ id: BlockId.WOOD, count: 2 }, null]);
+    const snapshot = cloneInventory(inventory);
+    const result = resolveCraft(inventory, "planks");
+
+    expectSuccess(result);
+    expect(inventory).toEqual(snapshot);
+    expect(result.inventory).not.toBe(inventory);
+  });
+});


### PR DESCRIPTION
## Add deterministic craftAction resolver with typed failures

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #243

### Changes
Create src/sim/craftAction.ts exporting a pure `resolveCraft(inventory: Inventory, recipeId: RecipeId): CraftActionResult` function that sits alongside the resolveMine/resolvePlace pattern in src/sim/actions.ts. The function should: (1) look up the recipe via the existing crafting registry in src/sim/crafting.ts, (2) on success return `{ ok: true, inventory: <new Inventory>, output: { item, count } }` where `inventory` is a new object with the consumed inputs removed and the crafted output added via the existing inventory helpers (addItem/removeItem) — never mutate the input inventory, (3) on failure return a typed discriminated result: `{ ok: false, reason: 'unknown_recipe', inventory }` for an unknown recipeId, and `{ ok: false, reason: 'insufficient_inputs', inventory, missing: <Partial<Record<ItemId, number>>> }` when at least one input is short. The returned `inventory` on the failure paths must be the original reference (no copy) so callers can short-circuit cheaply. Export the result types (e.g. `CraftActionResult`, `CraftFailureReason`) so input/app code can pattern-match. Add tests/sim/craftAction.test.ts with at least: a success case for each of the three MVP recipes ('planks', 'sticks', 'torch'); a missing-inputs failure that asserts `ok: false`, the correct reason, the missing map, and that the inventory reference is untouched; an unknown-recipe failure asserting reason and untouched inventory; and a non-mutation snapshot check on a successful craft (input inventory deep-equals its pre-call snapshot).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*