### PR TITLE
feature: Add seeded oreDistribution module with pure vein placement

### DIFF
--- a/src/sim/oreDistribution.ts
+++ b/src/sim/oreDistribution.ts
@@ -1,0 +1,111 @@
+import { BlockId } from "./blocks";
+import { CHUNK_SIZE, getBlock, inBounds, setBlock, type Chunk } from "./chunk";
+import { createRng, hashStringToSeed, nextInt, type Rng } from "./random";
+
+interface ChunkCoord {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+interface Coordinate {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+const VEIN_COUNT = 5;
+const MIN_VEIN_SIZE = 3;
+const MAX_VEIN_SIZE = 5;
+const START_ATTEMPTS_PER_VEIN = 16;
+const GROW_ATTEMPTS_PER_BLOCK = 12;
+const DIRECTIONS = [
+  { x: 1, y: 0, z: 0 },
+  { x: -1, y: 0, z: 0 },
+  { x: 0, y: 1, z: 0 },
+  { x: 0, y: -1, z: 0 },
+  { x: 0, y: 0, z: 1 },
+  { x: 0, y: 0, z: -1 }
+] as const satisfies readonly Coordinate[];
+
+export function distributeCoalOre(chunk: Chunk, seed: number, chunkCoord: ChunkCoord): void {
+  const rng = createRng(hashStringToSeed(`coal_ore:${seed}:${chunkCoord.x}:${chunkCoord.y}:${chunkCoord.z}`));
+
+  for (let veinIndex = 0; veinIndex < VEIN_COUNT; veinIndex += 1) {
+    const targetSize = nextInt(rng, MIN_VEIN_SIZE, MAX_VEIN_SIZE + 1);
+    const vein = planVein(chunk, rng, targetSize);
+
+    for (const coordinate of vein) {
+      setBlock(chunk, coordinate.x, coordinate.y, coordinate.z, BlockId.COAL_ORE);
+    }
+  }
+}
+
+function planVein(chunk: Chunk, rng: Rng, targetSize: number): Coordinate[] {
+  for (let attempt = 0; attempt < START_ATTEMPTS_PER_VEIN; attempt += 1) {
+    const start = randomCoordinate(rng);
+
+    if (getBlock(chunk, start.x, start.y, start.z) !== BlockId.STONE) {
+      continue;
+    }
+
+    const coordinates = [start];
+    const used = new Set<string>([coordinateKey(start)]);
+
+    while (coordinates.length < targetSize) {
+      const nextCoordinate = findAdjacentStone(chunk, rng, coordinates, used);
+
+      if (nextCoordinate === undefined) {
+        break;
+      }
+
+      coordinates.push(nextCoordinate);
+      used.add(coordinateKey(nextCoordinate));
+    }
+
+    if (coordinates.length >= MIN_VEIN_SIZE) {
+      return coordinates;
+    }
+  }
+
+  return [];
+}
+
+function findAdjacentStone(
+  chunk: Chunk,
+  rng: Rng,
+  coordinates: readonly Coordinate[],
+  used: ReadonlySet<string>
+): Coordinate | undefined {
+  for (let attempt = 0; attempt < GROW_ATTEMPTS_PER_BLOCK; attempt += 1) {
+    const base = coordinates[nextInt(rng, 0, coordinates.length)];
+    const direction = DIRECTIONS[nextInt(rng, 0, DIRECTIONS.length)];
+    const candidate = {
+      x: base.x + direction.x,
+      y: base.y + direction.y,
+      z: base.z + direction.z
+    };
+
+    if (
+      inBounds(candidate.x, candidate.y, candidate.z) &&
+      !used.has(coordinateKey(candidate)) &&
+      getBlock(chunk, candidate.x, candidate.y, candidate.z) === BlockId.STONE
+    ) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+function randomCoordinate(rng: Rng): Coordinate {
+  return {
+    x: nextInt(rng, 0, CHUNK_SIZE),
+    y: nextInt(rng, 0, CHUNK_SIZE),
+    z: nextInt(rng, 0, CHUNK_SIZE)
+  };
+}
+
+function coordinateKey(coordinate: Coordinate): string {
+  return `${coordinate.x},${coordinate.y},${coordinate.z}`;
+}

--- a/tests/sim/oreDistribution.test.ts
+++ b/tests/sim/oreDistribution.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import { CHUNK_SIZE, createChunk, getBlock, setBlock, type Chunk } from "../../src/sim/chunk";
+import { distributeCoalOre } from "../../src/sim/oreDistribution";
+
+describe("ore distribution", () => {
+  it("places coal ore deterministically for the same seed and coordinate", () => {
+    const chunkCoord = { x: 2, y: -1, z: 4 };
+    const first = stoneChunk();
+    const second = stoneChunk();
+
+    distributeCoalOre(first, 1337, chunkCoord);
+    distributeCoalOre(second, 1337, chunkCoord);
+
+    expect(coalOrePositions(first)).toEqual(coalOrePositions(second));
+    expect(Array.from(first.blocks)).toEqual(Array.from(second.blocks));
+  });
+
+  it("mixes chunk coordinates into independent placements", () => {
+    const first = stoneChunk();
+    const second = stoneChunk();
+
+    distributeCoalOre(first, 1337, { x: 0, y: 0, z: 0 });
+    distributeCoalOre(second, 1337, { x: 1, y: 0, z: 0 });
+
+    expect(coalOrePositions(first)).not.toEqual(coalOrePositions(second));
+  });
+
+  it("only converts stone blocks into coal ore", () => {
+    const chunk = stoneChunk();
+
+    distributeCoalOre(chunk, 2026, { x: 0, y: 0, z: 0 });
+
+    forEachBlock(chunk, (block) => {
+      expect([BlockId.STONE, BlockId.COAL_ORE]).toContain(block);
+    });
+  });
+
+  it("leaves air, grass, dirt, and other non-stone blocks untouched", () => {
+    const chunk = stoneChunk();
+    const protectedBlocks = [
+      { x: 1, y: 2, z: 3, id: BlockId.AIR },
+      { x: 4, y: 5, z: 6, id: BlockId.GRASS },
+      { x: 7, y: 8, z: 9, id: BlockId.DIRT },
+      { x: 10, y: 11, z: 12, id: BlockId.TORCH }
+    ] as const;
+
+    for (const block of protectedBlocks) {
+      setBlock(chunk, block.x, block.y, block.z, block.id);
+    }
+
+    distributeCoalOre(chunk, 2026, { x: 0, y: 0, z: 0 });
+
+    for (const block of protectedBlocks) {
+      expect(getBlock(chunk, block.x, block.y, block.z)).toBe(block.id);
+    }
+  });
+
+  it("keeps a fixed seed fixture pinned to exact coordinates", () => {
+    const chunk = stoneChunk();
+
+    distributeCoalOre(chunk, 2468, { x: -3, y: 1, z: 5 });
+
+    expect(coalOrePositions(chunk)).toContain("14,3,9");
+  });
+});
+
+function stoneChunk(): Chunk {
+  const chunk = createChunk();
+
+  forEachCoordinate((x, y, z) => {
+    setBlock(chunk, x, y, z, BlockId.STONE);
+  });
+
+  return chunk;
+}
+
+function coalOrePositions(chunk: Chunk): string[] {
+  const positions: string[] = [];
+
+  forEachCoordinate((x, y, z) => {
+    if (getBlock(chunk, x, y, z) === BlockId.COAL_ORE) {
+      positions.push(`${x},${y},${z}`);
+    }
+  });
+
+  return positions;
+}
+
+function forEachBlock(chunk: Chunk, fn: (block: BlockId) => void): void {
+  forEachCoordinate((x, y, z) => {
+    fn(getBlock(chunk, x, y, z));
+  });
+}
+
+function forEachCoordinate(fn: (x: number, y: number, z: number) => void): void {
+  for (let y = 0; y < CHUNK_SIZE; y += 1) {
+    for (let z = 0; z < CHUNK_SIZE; z += 1) {
+      for (let x = 0; x < CHUNK_SIZE; x += 1) {
+        fn(x, y, z);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Add seeded oreDistribution module with pure vein placement

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #237

### Changes
Create src/sim/oreDistribution.ts exporting a pure function `distributeCoalOre(chunk: Chunk, seed: number, chunkCoord: { x: number; y: number; z: number }): void` (or a similarly named pure function — return the chunk if you prefer immutable style). The function must scatter small coal_ore veins (e.g. 3-5 connected blocks each) only into existing BlockId.STONE cells, never replacing GRASS, DIRT, AIR, or any non-stone block. Use the seeded RNG in src/sim/random.ts mixed with chunkCoord so calling it twice with the same (seed, chunkCoord) produces byte-identical results, and different chunkCoords produce independent placements. In tests/sim/oreDistribution.test.ts, assert: (1) determinism — two calls with same inputs yield same coal_ore positions; (2) independence — different chunkCoords differ; (3) only stone cells are converted (build a chunk filled with stone, run distribution, verify no non-STONE/non-COAL_ORE blocks appear and no AIR/GRASS/DIRT cells were touched in a mixed fixture); (4) at least one expected vein position for a fixed (seed, chunkCoord) is asserted by exact coordinates so future regressions are caught.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*