### PR TITLE
feature: Define MVP recipe registry (planks, sticks, torch)

### DIFF
--- a/src/sim/recipes.ts
+++ b/src/sim/recipes.ts
@@ -1,0 +1,52 @@
+import { BlockId } from "./blocks";
+
+export type MvpRecipeName = "planks" | "sticks" | "torch";
+
+export interface MvpRecipeInput {
+  readonly item: BlockId;
+  readonly count: number;
+}
+
+export interface MvpRecipeOutput {
+  readonly item: BlockId;
+  readonly count: number;
+}
+
+export interface MvpRecipe {
+  readonly id: MvpRecipeName;
+  readonly inputs: ReadonlyArray<MvpRecipeInput>;
+  readonly output: MvpRecipeOutput;
+}
+
+const PLANKS_RECIPE: MvpRecipe = Object.freeze({
+  id: "planks",
+  inputs: Object.freeze([Object.freeze({ item: BlockId.WOOD, count: 1 })]),
+  output: Object.freeze({ item: BlockId.PLANKS, count: 4 })
+});
+
+const STICKS_RECIPE: MvpRecipe = Object.freeze({
+  id: "sticks",
+  inputs: Object.freeze([Object.freeze({ item: BlockId.PLANKS, count: 2 })]),
+  output: Object.freeze({ item: BlockId.STICK, count: 4 })
+});
+
+const TORCH_RECIPE: MvpRecipe = Object.freeze({
+  id: "torch",
+  inputs: Object.freeze([
+    Object.freeze({ item: BlockId.STICK, count: 1 }),
+    Object.freeze({ item: BlockId.COAL, count: 1 })
+  ]),
+  output: Object.freeze({ item: BlockId.TORCH, count: 4 })
+});
+
+export const MVP_RECIPES: ReadonlyArray<MvpRecipe> = Object.freeze([
+  PLANKS_RECIPE,
+  STICKS_RECIPE,
+  TORCH_RECIPE
+]);
+
+export const MVP_RECIPES_BY_NAME: Readonly<Record<MvpRecipeName, MvpRecipe>> = Object.freeze({
+  planks: PLANKS_RECIPE,
+  sticks: STICKS_RECIPE,
+  torch: TORCH_RECIPE
+});

--- a/tests/sim/recipes.test.ts
+++ b/tests/sim/recipes.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import { craft, type Inventory } from "../../src/sim/crafting";
+import {
+  MVP_RECIPES,
+  MVP_RECIPES_BY_NAME,
+  type MvpRecipeInput
+} from "../../src/sim/recipes";
+
+function expectSuccess(result: ReturnType<typeof craft>): asserts result is Extract<ReturnType<typeof craft>, { ok: true }> {
+  expect(result.ok).toBe(true);
+}
+
+function inventoryFromInputs(inputs: ReadonlyArray<MvpRecipeInput>): Inventory {
+  const inventory: Record<number, number> = {};
+
+  for (const input of inputs) {
+    inventory[input.item] = input.count;
+  }
+
+  return inventory;
+}
+
+describe("MVP recipe registry", () => {
+  it("defines the MVP recipe ids, inputs, and outputs", () => {
+    expect(MVP_RECIPES).toEqual([
+      {
+        id: "planks",
+        inputs: [{ item: BlockId.WOOD, count: 1 }],
+        output: { item: BlockId.PLANKS, count: 4 }
+      },
+      {
+        id: "sticks",
+        inputs: [{ item: BlockId.PLANKS, count: 2 }],
+        output: { item: BlockId.STICK, count: 4 }
+      },
+      {
+        id: "torch",
+        inputs: [
+          { item: BlockId.STICK, count: 1 },
+          { item: BlockId.COAL, count: 1 }
+        ],
+        output: { item: BlockId.TORCH, count: 4 }
+      }
+    ]);
+
+    for (const recipe of MVP_RECIPES) {
+      expect(MVP_RECIPES_BY_NAME[recipe.id]).toBe(recipe);
+    }
+  });
+
+  it("round-trips every registry recipe through craft", () => {
+    for (const recipe of MVP_RECIPES) {
+      const result = craft(inventoryFromInputs(recipe.inputs), recipe.id);
+
+      expectSuccess(result);
+      expect(result.inventory).toEqual({});
+      expect(result.output).toEqual(recipe.output);
+    }
+  });
+
+  it("keeps the torch stone fallback compatible with the registry output", () => {
+    const result = craft({ [BlockId.STICK]: 1, [BlockId.STONE]: 1 }, "torch");
+
+    expectSuccess(result);
+    expect(result.inventory).toEqual({});
+    expect(result.output).toEqual(MVP_RECIPES_BY_NAME.torch.output);
+  });
+
+  it("freezes the registry, lookup, and nested recipe records", () => {
+    expect(Object.isFrozen(MVP_RECIPES)).toBe(true);
+    expect(Object.isFrozen(MVP_RECIPES_BY_NAME)).toBe(true);
+
+    for (const recipe of MVP_RECIPES) {
+      expect(Object.isFrozen(recipe)).toBe(true);
+      expect(Object.isFrozen(recipe.inputs)).toBe(true);
+      expect(Object.isFrozen(recipe.output)).toBe(true);
+
+      for (const input of recipe.inputs) {
+        expect(Object.isFrozen(input)).toBe(true);
+      }
+    }
+  });
+
+  it("iterates recipes in deterministic order", () => {
+    const firstPass = Array.from(MVP_RECIPES, (recipe) => recipe.id);
+    const secondPass = Array.from(MVP_RECIPES, (recipe) => recipe.id);
+
+    expect(firstPass).toEqual(["planks", "sticks", "torch"]);
+    expect(secondPass).toEqual(firstPass);
+  });
+});


### PR DESCRIPTION
## Define MVP recipe registry (planks, sticks, torch)

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #247

### Changes
Create src/sim/recipes.ts that exports a frozen, deterministic registry of the three MVP recipes called out in the product spec: planks from wood logs, sticks from planks, and a torch from a stick plus coal (with stone as fallback). Read src/sim/crafting.ts to understand the existing `craft(inventory, recipeName)` API and reuse the same recipe identifiers ('planks', 'sticks', 'torch') and ItemId/BlockId values from src/sim/items.ts and src/sim/blocks.ts. Each recipe must be a pure data record describing inputs (item id + count), output (item id + count), and the recipe name; export the collection as `MVP_RECIPES` (a `readonly` array) and a `MVP_RECIPES_BY_NAME` lookup, both frozen with `Object.freeze` (deeply, including each recipe and its input arrays). Then add tests/sim/recipes.test.ts that asserts: (a) input/output ids and counts match the spec exactly for all three recipes, (b) each recipe round-trips through `craft()` against a hand-built inventory containing exactly the listed inputs and produces the registry's declared output, (c) `Object.isFrozen` returns true for the array, the lookup, and every nested recipe/input record, and (d) iterating the registry twice returns identical results (deterministic ordering). Do not modify src/sim/crafting.ts — recipes.ts is a separate data module that mirrors the spec.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*