### PR TITLE
feature: Add HUD coordinates label component with tests

### DIFF
--- a/src/hud/coordinatesLabel.ts
+++ b/src/hud/coordinatesLabel.ts
@@ -1,0 +1,30 @@
+export interface CoordinatesPosition {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface CoordinatesLabel {
+  element: HTMLElement;
+  update: (pos: CoordinatesPosition) => void;
+}
+
+function formatCoordinatesText(pos: CoordinatesPosition): string {
+  return `X: ${Math.round(pos.x)} Y: ${Math.round(pos.y)} Z: ${Math.round(pos.z)}`;
+}
+
+export function createCoordinatesLabel(): CoordinatesLabel {
+  const element = document.createElement("div");
+  element.dataset.testid = "hud-coordinates";
+
+  function update(pos: CoordinatesPosition): void {
+    element.textContent = formatCoordinatesText(pos);
+  }
+
+  update({ x: 0, y: 0, z: 0 });
+
+  return {
+    element,
+    update
+  };
+}

--- a/tests/hud/coordinatesLabel.test.ts
+++ b/tests/hud/coordinatesLabel.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { createCoordinatesLabel } from "../../src/hud/coordinatesLabel";
+
+describe("coordinates HUD", () => {
+  it("returns a div with the stable test selector and default text", () => {
+    const coordinatesLabel = createCoordinatesLabel();
+
+    expect(coordinatesLabel.element.tagName).toBe("DIV");
+    expect(coordinatesLabel.element.dataset.testid).toBe("hud-coordinates");
+    expect(coordinatesLabel.element.textContent).toBe("X: 0 Y: 0 Z: 0");
+  });
+
+  it("rounds fractional inputs before writing text", () => {
+    const coordinatesLabel = createCoordinatesLabel();
+
+    coordinatesLabel.update({ x: 1.4, y: 2.6, z: -0.5 });
+
+    expect(coordinatesLabel.element.textContent).toBe("X: 1 Y: 3 Z: 0");
+  });
+
+  it("reflects only the latest update", () => {
+    const coordinatesLabel = createCoordinatesLabel();
+
+    coordinatesLabel.update({ x: 5, y: 6, z: 7 });
+    coordinatesLabel.update({ x: -2.2, y: 10.5, z: 99.1 });
+
+    expect(coordinatesLabel.element.textContent).toBe("X: -2 Y: 11 Z: 99");
+  });
+
+  it("keeps the same node and selector across repeated updates", () => {
+    const coordinatesLabel = createCoordinatesLabel();
+    const element = coordinatesLabel.element;
+
+    coordinatesLabel.update({ x: 1, y: 2, z: 3 });
+    coordinatesLabel.update({ x: 4, y: 5, z: 6 });
+
+    expect(coordinatesLabel.element).toBe(element);
+    expect(coordinatesLabel.element.dataset.testid).toBe("hud-coordinates");
+  });
+});


### PR DESCRIPTION
## Add HUD coordinates label component with tests

**Category:** `feature` | **Contributor:** uJJZGeu2imjA7Z8Fp-tXL

Closes #246

### Changes
Create src/hud/coordinatesLabel.ts that exports a factory (e.g. createCoordinatesLabel) returning an object shaped like { element: HTMLElement, update(pos: { x: number; y: number; z: number }): void }. The element must be a div with element.dataset.testid = 'hud-coordinates' (matching the kebab/scheme used by saveStatus.ts and hotbar.ts so Playwright can select it). On creation, render a deterministic initial label (e.g. 'X: 0 Y: 0 Z: 0' from a default position of 0,0,0). The update method must round each component to an integer with Math.round before formatting and write the result to element.textContent so the label reflects the latest player position. Mirror the export and naming style of src/hud/saveStatus.ts. Add tests in tests/hud/coordinatesLabel.test.ts that cover: (1) initial render produces an element whose dataset.testid is 'hud-coordinates' with the deterministic default text, (2) update() rounds fractional inputs (e.g. { x: 1.4, y: 2.6, z: -0.5 } → integer values, e.g. 1, 3, 0 — match Math.round semantics) and writes them to textContent, (3) update() can be called multiple times and the textContent reflects only the latest call, (4) selector stability — after multiple updates the element returned remains the same node and the data-testid attribute is unchanged. Do NOT modify src/hud/index.ts in this task (the comment slot is just contextual).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*