### PR TITLE
feature: Add crafting HUD panel that lists recipes and emits craft intents

### DIFF
--- a/src/hud/craftingPanel.ts
+++ b/src/hud/craftingPanel.ts
@@ -1,0 +1,79 @@
+import { RECIPES } from "../sim/crafting";
+import type { RecipeInput } from "../sim/crafting";
+import type { BlockId } from "../sim/blocks";
+import type { Inventory } from "../sim/inventory";
+
+const RECIPE_IDS = ["planks", "sticks", "torch"] as const satisfies ReadonlyArray<keyof typeof RECIPES>;
+
+export type CraftingRecipeId = (typeof RECIPE_IDS)[number];
+export type CraftIntentListener = (recipeId: CraftingRecipeId) => void;
+
+export interface CraftingPanel {
+  readonly element: HTMLElement;
+  update(snapshot: Inventory): void;
+  onCraft(listener: CraftIntentListener): void;
+}
+
+function serializeRequiredInputs(inputs: ReadonlyArray<RecipeInput>): string {
+  return inputs.map((input) => `${input.item}:${input.count}`).join(",");
+}
+
+function getInventoryTotals(snapshot: Inventory): ReadonlyMap<BlockId, number> {
+  const totals = new Map<BlockId, number>();
+
+  for (const slot of snapshot.slots) {
+    if (slot === null) {
+      continue;
+    }
+
+    totals.set(slot.id, (totals.get(slot.id) ?? 0) + slot.count);
+  }
+
+  return totals;
+}
+
+function hasInputs(totals: ReadonlyMap<BlockId, number>, inputs: ReadonlyArray<RecipeInput>): boolean {
+  return inputs.every((input) => (totals.get(input.item) ?? 0) >= input.count);
+}
+
+export function createCraftingPanel(): CraftingPanel {
+  const element = document.createElement("div");
+  const listeners = new Set<CraftIntentListener>();
+  let totals: ReadonlyMap<BlockId, number> = new Map<BlockId, number>();
+
+  element.dataset.testid = "crafting-panel";
+
+  function createRecipeRow(recipeId: CraftingRecipeId): HTMLElement {
+    const recipe = RECIPES[recipeId];
+    const row = document.createElement("div");
+
+    row.dataset.recipeId = recipeId;
+    row.dataset.craftable = String(hasInputs(totals, recipe.inputs));
+    row.dataset.requiredInputs = serializeRequiredInputs(recipe.inputs);
+    row.textContent = recipe.id;
+    row.addEventListener("click", () => {
+      for (const listener of listeners) {
+        listener(recipeId);
+      }
+    });
+
+    return row;
+  }
+
+  function render(): void {
+    element.replaceChildren(...RECIPE_IDS.map((recipeId) => createRecipeRow(recipeId)));
+  }
+
+  render();
+
+  return {
+    element,
+    update(snapshot) {
+      totals = getInventoryTotals(snapshot);
+      render();
+    },
+    onCraft(listener) {
+      listeners.add(listener);
+    }
+  };
+}

--- a/tests/hud/craftingPanel.test.ts
+++ b/tests/hud/craftingPanel.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createCraftingPanel } from "../../src/hud/craftingPanel";
+import { BlockId } from "../../src/sim/blocks";
+import type { Inventory } from "../../src/sim/inventory";
+
+function makeInventory(slots: Inventory["slots"]): Inventory {
+  return {
+    slots,
+    selectedHotbarSlot: 0
+  };
+}
+
+function getCraftingRoot(): HTMLElement {
+  const root = document.querySelector<HTMLElement>('[data-testid="crafting-panel"]');
+
+  if (root === null) {
+    throw new Error("Crafting panel was not rendered");
+  }
+
+  return root;
+}
+
+function getRecipeRows(): HTMLElement[] {
+  return Array.from(getCraftingRoot().querySelectorAll<HTMLElement>("[data-recipe-id]"));
+}
+
+function readRenderedRecipes(): Array<{ id: string; requiredInputs: string; craftable: string }> {
+  return getRecipeRows().map((row) => ({
+    id: row.dataset.recipeId ?? "",
+    requiredInputs: row.dataset.requiredInputs ?? "",
+    craftable: row.dataset.craftable ?? ""
+  }));
+}
+
+describe("crafting panel", () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("renders all recipe rows in source order with deterministic input data", () => {
+    const panel = createCraftingPanel();
+    document.body.append(panel.element);
+
+    expect(readRenderedRecipes()).toEqual([
+      { id: "planks", requiredInputs: `${BlockId.WOOD}:1`, craftable: "false" },
+      { id: "sticks", requiredInputs: `${BlockId.PLANKS}:2`, craftable: "false" },
+      { id: "torch", requiredInputs: `${BlockId.STICK}:1,${BlockId.COAL}:1`, craftable: "false" }
+    ]);
+  });
+
+  it("flips craftable data when inventory satisfies recipe inputs across slots", () => {
+    const panel = createCraftingPanel();
+    document.body.append(panel.element);
+
+    panel.update(makeInventory([null, { id: BlockId.PLANKS, count: 1 }]));
+    expect(readRenderedRecipes().find((recipe) => recipe.id === "sticks")?.craftable).toBe("false");
+
+    panel.update(makeInventory([{ id: BlockId.PLANKS, count: 1 }, null, { id: BlockId.PLANKS, count: 1 }]));
+    expect(readRenderedRecipes().find((recipe) => recipe.id === "sticks")?.craftable).toBe("true");
+  });
+
+  it("updates craftable data deterministically for different inventories", () => {
+    const panel = createCraftingPanel();
+    document.body.append(panel.element);
+
+    panel.update(makeInventory([{ id: BlockId.STICK, count: 1 }, { id: BlockId.COAL, count: 1 }]));
+    const withTorchInputs = readRenderedRecipes();
+
+    panel.update(makeInventory([{ id: BlockId.WOOD, count: 1 }]));
+    const withWood = readRenderedRecipes();
+
+    panel.update(makeInventory([{ id: BlockId.WOOD, count: 1 }]));
+    const withWoodAgain = readRenderedRecipes();
+
+    expect(withTorchInputs).toEqual([
+      { id: "planks", requiredInputs: `${BlockId.WOOD}:1`, craftable: "false" },
+      { id: "sticks", requiredInputs: `${BlockId.PLANKS}:2`, craftable: "false" },
+      { id: "torch", requiredInputs: `${BlockId.STICK}:1,${BlockId.COAL}:1`, craftable: "true" }
+    ]);
+    expect(withWood).toEqual([
+      { id: "planks", requiredInputs: `${BlockId.WOOD}:1`, craftable: "true" },
+      { id: "sticks", requiredInputs: `${BlockId.PLANKS}:2`, craftable: "false" },
+      { id: "torch", requiredInputs: `${BlockId.STICK}:1,${BlockId.COAL}:1`, craftable: "false" }
+    ]);
+    expect(withWoodAgain).toEqual(withWood);
+  });
+
+  it("emits craft intents to every listener when a recipe row is clicked", () => {
+    const panel = createCraftingPanel();
+    const firstListenerCalls: string[] = [];
+    const secondListenerCalls: string[] = [];
+
+    document.body.append(panel.element);
+    panel.onCraft((recipeId) => firstListenerCalls.push(recipeId));
+    panel.onCraft((recipeId) => secondListenerCalls.push(recipeId));
+
+    getRecipeRows()[0]?.click();
+
+    expect(firstListenerCalls).toEqual(["planks"]);
+    expect(secondListenerCalls).toEqual(["planks"]);
+  });
+
+  it("renders all rows as non-craftable before update is called", () => {
+    const panel = createCraftingPanel();
+    document.body.append(panel.element);
+
+    expect(readRenderedRecipes()).toEqual([
+      { id: "planks", requiredInputs: `${BlockId.WOOD}:1`, craftable: "false" },
+      { id: "sticks", requiredInputs: `${BlockId.PLANKS}:2`, craftable: "false" },
+      { id: "torch", requiredInputs: `${BlockId.STICK}:1,${BlockId.COAL}:1`, craftable: "false" }
+    ]);
+  });
+});


### PR DESCRIPTION
## Add crafting HUD panel that lists recipes and emits craft intents

**Category:** `feature` | **Contributor:** lGcXT7PMKKsHZLFttzBf-

Closes #252

### Changes
Create src/hud/craftingPanel.ts and tests/hud/craftingPanel.test.ts. Export a createCraftingPanel() factory that follows the createInventoryPanel pattern in src/hud/inventoryPanel.ts and returns at minimum { element, update(inventory), onCraft(listener) }. Requirements: (1) The root element must carry data-testid="crafting-panel" and render exactly the three MVP recipes from the RECIPES export in src/sim/crafting.ts (planks, sticks, torch) in a stable, deterministic order — iterate the keys in the source order they appear in RECIPES rather than Object.keys ordering tricks. (2) Each recipe row must expose stable data attributes: data-recipe-id (the recipe key, e.g. "planks"), data-craftable ("true" or "false") computed from the most recent inventory passed to update(), and data-required-inputs giving a deterministic representation of inputs (e.g. comma-joined "<BlockId>:<count>" pairs in the order they appear in the recipe's inputs array). (3) Provide onCraft(listener) registering a callback invoked with the recipe id when a recipe row is activated (click on the row element). Multiple listeners should all fire; clicking a non-craftable row should still emit (the panel reports intent, the resolver decides). (4) update(inventory) must be idempotent and produce a deterministic DOM snapshot for the same inventory. Accept the slot-based Inventory type from src/sim/inventory.ts and compute item totals across slots when checking craftability against the recipe's RecipeInput[]. (5) Tests in tests/hud/craftingPanel.test.ts must cover: initial render renders all three recipe rows in source order with correct data-recipe-id and data-required-inputs; data-craftable flips from "false" to "true" when update() is called with an inventory that satisfies the recipe's inputs (use BlockId from src/sim/blocks.ts); calling update() with a different inventory updates data-craftable deterministically; clicking a recipe row invokes onCraft listeners with that recipe's id; the panel renders even when update() has not been called (all rows present, data-craftable="false").

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*