### PR TITLE
feature: Add Digit1–Digit9 hotbar selection input adapter

### DIFF
--- a/src/input/hotbarKeys.ts
+++ b/src/input/hotbarKeys.ts
@@ -1,0 +1,118 @@
+import { selectHotbarIntent, type SelectHotbarIntent } from "./intents";
+import type {
+  KeyboardEventLike,
+  KeyboardEventListener,
+  KeyboardEventSource
+} from "./keyboard";
+
+interface KeyboardModifierState {
+  readonly ctrlKey?: boolean;
+  readonly shiftKey?: boolean;
+  readonly altKey?: boolean;
+  readonly metaKey?: boolean;
+}
+
+export interface HotbarKeysAdapterOptions {
+  readonly hotbarSize: number;
+}
+
+export type HotbarKeysIntentSubscriber = (intent: SelectHotbarIntent) => void;
+
+export interface HotbarKeysAdapter {
+  subscribe(subscriber: HotbarKeysIntentSubscriber): () => void;
+  dispose(): void;
+}
+
+function digitSlot(code: string | undefined): number | null {
+  if (code === undefined || !/^Digit[1-9]$/.test(code)) {
+    return null;
+  }
+
+  return Number(code.slice("Digit".length)) - 1;
+}
+
+function hasModifier(event: KeyboardEventLike & KeyboardModifierState): boolean {
+  return (
+    event.ctrlKey === true ||
+    event.shiftKey === true ||
+    event.altKey === true ||
+    event.metaKey === true
+  );
+}
+
+export function createHotbarKeysAdapter(
+  source: KeyboardEventSource,
+  options: HotbarKeysAdapterOptions
+): HotbarKeysAdapter {
+  if (!Number.isInteger(options.hotbarSize) || options.hotbarSize <= 0) {
+    throw new Error("Hotbar size must be a positive integer.");
+  }
+
+  const subscribers = new Set<HotbarKeysIntentSubscriber>();
+  const pressedCodes = new Set<string>();
+  let disposed = false;
+
+  function emit(intent: SelectHotbarIntent): void {
+    if (disposed) {
+      return;
+    }
+
+    for (const subscriber of subscribers) {
+      subscriber(intent);
+    }
+  }
+
+  const onKeyDown: KeyboardEventListener = (event) => {
+    const code = event.code;
+    const slot = digitSlot(code);
+
+    if (
+      code === undefined ||
+      slot === null ||
+      slot >= options.hotbarSize ||
+      event.repeat === true ||
+      hasModifier(event) ||
+      pressedCodes.has(code)
+    ) {
+      return;
+    }
+
+    pressedCodes.add(code);
+    emit(selectHotbarIntent(slot));
+  };
+
+  const onKeyUp: KeyboardEventListener = (event) => {
+    const code = event.code;
+
+    if (code !== undefined && digitSlot(code) !== null) {
+      pressedCodes.delete(code);
+    }
+  };
+
+  source.addEventListener("keydown", onKeyDown);
+  source.addEventListener("keyup", onKeyUp);
+
+  return {
+    subscribe(subscriber) {
+      if (disposed) {
+        return () => undefined;
+      }
+
+      subscribers.add(subscriber);
+      return () => {
+        subscribers.delete(subscriber);
+      };
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+
+      disposed = true;
+      source.removeEventListener("keydown", onKeyDown);
+      source.removeEventListener("keyup", onKeyUp);
+      subscribers.clear();
+      pressedCodes.clear();
+    }
+  };
+}

--- a/tests/input/hotbarKeys.test.ts
+++ b/tests/input/hotbarKeys.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import { createHotbarKeysAdapter } from "../../src/input/hotbarKeys";
+import { selectHotbarIntent, type SelectHotbarIntent } from "../../src/input/intents";
+import type {
+  KeyboardEventLike,
+  KeyboardEventListener,
+  KeyboardEventName,
+  KeyboardEventSource
+} from "../../src/input/keyboard";
+
+interface HotbarKeyboardEventLike extends KeyboardEventLike {
+  readonly ctrlKey?: boolean;
+  readonly shiftKey?: boolean;
+  readonly altKey?: boolean;
+  readonly metaKey?: boolean;
+}
+
+class FakeKeyboardEventSource implements KeyboardEventSource {
+  private readonly listeners: Record<KeyboardEventName, KeyboardEventListener[]> = {
+    keydown: [],
+    keyup: []
+  };
+
+  addEventListener(type: KeyboardEventName, listener: KeyboardEventListener): void {
+    this.listeners[type].push(listener);
+  }
+
+  removeEventListener(type: KeyboardEventName, listener: KeyboardEventListener): void {
+    this.listeners[type] = this.listeners[type].filter((candidate) => candidate !== listener);
+  }
+
+  dispatch(type: KeyboardEventName, event: HotbarKeyboardEventLike): void {
+    for (const listener of this.listeners[type]) {
+      listener(event);
+    }
+  }
+
+  listenerCount(type: KeyboardEventName): number {
+    return this.listeners[type].length;
+  }
+}
+
+function createSubscribedAdapter(hotbarSize = 9): {
+  readonly source: FakeKeyboardEventSource;
+  readonly emitted: SelectHotbarIntent[];
+} {
+  const source = new FakeKeyboardEventSource();
+  const adapter = createHotbarKeysAdapter(source, { hotbarSize });
+  const emitted: SelectHotbarIntent[] = [];
+
+  adapter.subscribe((intent) => {
+    emitted.push(intent);
+  });
+
+  return { source, emitted };
+}
+
+describe("hotbar keys adapter", () => {
+  it("emits Digit1 and Digit5 as zero-indexed hotbar slots", () => {
+    const { source, emitted } = createSubscribedAdapter();
+
+    source.dispatch("keydown", { code: "Digit1" });
+    source.dispatch("keydown", { code: "Digit5" });
+
+    expect(emitted).toEqual([selectHotbarIntent(0), selectHotbarIntent(4)]);
+  });
+
+  it("drops digit slots beyond the configured hotbar size", () => {
+    const { source, emitted } = createSubscribedAdapter(4);
+
+    source.dispatch("keydown", { code: "Digit4" });
+    source.dispatch("keydown", { code: "Digit5" });
+
+    expect(emitted).toEqual([selectHotbarIntent(3)]);
+  });
+
+  it("emits once for repeated keydowns until the matching keyup", () => {
+    const { source, emitted } = createSubscribedAdapter();
+
+    source.dispatch("keydown", { code: "Digit2" });
+    source.dispatch("keydown", { code: "Digit2" });
+    source.dispatch("keydown", { code: "Digit2" });
+    source.dispatch("keyup", { code: "Digit2" });
+    source.dispatch("keydown", { code: "Digit2" });
+
+    expect(emitted).toEqual([selectHotbarIntent(1), selectHotbarIntent(1)]);
+  });
+
+  it("ignores native repeat keydown events", () => {
+    const { source, emitted } = createSubscribedAdapter();
+
+    source.dispatch("keydown", { code: "Digit3", repeat: true });
+
+    expect(emitted).toEqual([]);
+  });
+
+  it("ignores keydown events with modifiers held", () => {
+    const { source, emitted } = createSubscribedAdapter();
+
+    source.dispatch("keydown", { code: "Digit1", ctrlKey: true });
+    source.dispatch("keydown", { code: "Digit2", shiftKey: true });
+    source.dispatch("keydown", { code: "Digit3", altKey: true });
+    source.dispatch("keydown", { code: "Digit4", metaKey: true });
+
+    expect(emitted).toEqual([]);
+  });
+
+  it("ignores non-digit keys", () => {
+    const { source, emitted } = createSubscribedAdapter();
+
+    source.dispatch("keydown", { code: "Digit0" });
+    source.dispatch("keydown", { code: "KeyQ" });
+    source.dispatch("keydown", { key: "1" });
+
+    expect(emitted).toEqual([]);
+  });
+
+  it("emits intents to multiple subscribers", () => {
+    const source = new FakeKeyboardEventSource();
+    const adapter = createHotbarKeysAdapter(source, { hotbarSize: 9 });
+    const first: SelectHotbarIntent[] = [];
+    const second: SelectHotbarIntent[] = [];
+
+    adapter.subscribe((intent) => {
+      first.push(intent);
+    });
+    adapter.subscribe((intent) => {
+      second.push(intent);
+    });
+
+    source.dispatch("keydown", { code: "Digit9" });
+
+    expect(first).toEqual([selectHotbarIntent(8)]);
+    expect(second).toEqual([selectHotbarIntent(8)]);
+  });
+
+  it("stops sending intents to unsubscribed listeners", () => {
+    const source = new FakeKeyboardEventSource();
+    const adapter = createHotbarKeysAdapter(source, { hotbarSize: 9 });
+    const emitted: SelectHotbarIntent[] = [];
+    const unsubscribe = adapter.subscribe((intent) => {
+      emitted.push(intent);
+    });
+
+    source.dispatch("keydown", { code: "Digit1" });
+    unsubscribe();
+    source.dispatch("keydown", { code: "Digit2" });
+
+    expect(emitted).toEqual([selectHotbarIntent(0)]);
+  });
+
+  it("removes keydown and keyup listeners on dispose", () => {
+    const source = new FakeKeyboardEventSource();
+    const adapter = createHotbarKeysAdapter(source, { hotbarSize: 9 });
+    const emitted: SelectHotbarIntent[] = [];
+
+    adapter.subscribe((intent) => {
+      emitted.push(intent);
+    });
+
+    expect(source.listenerCount("keydown")).toBe(1);
+    expect(source.listenerCount("keyup")).toBe(1);
+
+    adapter.dispose();
+    source.dispatch("keydown", { code: "Digit1" });
+    source.dispatch("keyup", { code: "Digit1" });
+
+    expect(source.listenerCount("keydown")).toBe(0);
+    expect(source.listenerCount("keyup")).toBe(0);
+    expect(emitted).toEqual([]);
+  });
+
+  it("rejects non-positive integer hotbar sizes", () => {
+    const source = new FakeKeyboardEventSource();
+
+    expect(() => createHotbarKeysAdapter(source, { hotbarSize: 0 })).toThrow(
+      "Hotbar size must be a positive integer."
+    );
+    expect(() => createHotbarKeysAdapter(source, { hotbarSize: 1.5 })).toThrow(
+      "Hotbar size must be a positive integer."
+    );
+  });
+});


### PR DESCRIPTION
## Add Digit1–Digit9 hotbar selection input adapter

**Category:** `feature` | **Contributor:** s6w7ianKS72_7SJk08DnO

Closes #251

### Changes
Create `src/input/hotbarKeys.ts` exporting a `createHotbarKeysAdapter` factory that subscribes to a `KeyboardEventSource` (reuse the type from `src/input/keyboard.ts` if exported, otherwise define a structurally compatible local interface) and emits `selectHotbarIntent(slot)` intents (from `src/input/intents.ts`) when Digit1..Digit9 are pressed. Behavior requirements: (1) accept a `hotbarSize: number` option (positive integer) and clamp/ignore digit presses whose 0-indexed slot (Digit1 → 0 ... Digit9 → 8) is >= hotbarSize — these must NOT emit; (2) only fire on the initial `keydown` for a given digit — ignore native auto-repeat (events with `repeat === true`) AND ignore subsequent keydowns until the matching `keyup` arrives, so holding the key produces exactly one intent; (3) ignore any keydown where any modifier is held (`ctrlKey`, `shiftKey`, `altKey`, or `metaKey` truthy); (4) the adapter exposes `subscribe(listener)` returning an unsubscribe function and a `dispose()` method that removes its keyboard listeners. Add a thorough test file at `tests/input/hotbarKeys.test.ts` that uses a fake `KeyboardEventSource` (mirror the pattern in `tests/input/keyboard.test.ts`) to verify: Digit1→slot 0, Digit5→slot 4, slots beyond `hotbarSize` are dropped, repeated keydowns without keyup emit once, `repeat: true` events emit nothing, modifier-held presses emit nothing, non-digit keys are ignored, multiple subscribers all receive intents, unsubscribe stops further intents, and `dispose()` removes both keydown and keyup listeners (exposed via a helper on the fake source).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*