### PR TITLE
Fix real MVP world interactions

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -42,7 +42,20 @@ The MVP should be small but real: a deterministic seeded voxel world, first-pers
 - Contributors must keep modules focused: simulation, rendering, controls, inventory, crafting, persistence, and UI should be separable.
 
 ## Verification
-- MVP verification: seeded world loads, player can move, mine one block, place one block, craft one item, and save/reload locally.
+- type: web
+- build: pnpm build
+- serve: pnpm exec vite preview --host 127.0.0.1 --port 4173 --strictPort
+- url: http://127.0.0.1:4173
+- ready_signal: Local:
+- runtime:
+  - pnpm exec playwright test tests/e2e/mvp.spec.ts
+- acceptance:
+  - Seeded world loads without console/runtime errors.
+  - Player can move with keyboard input.
+  - Player can mine one block and see inventory update.
+  - Player can place one block and see world status update.
+  - Player can craft planks from wood.
+  - Player can save, reload, and observe persisted inventory/state.
 - Harden verification: unit tests and at least one Playwright happy path pass reliably in a clean install.
 - Human gate: after hardening drains, a human should play the browser build for at least five minutes and confirm the loop is understandable.
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,18 +1,25 @@
 import { defineConfig } from "@playwright/test";
 
-const port = 5173;
-const baseURL = `http://127.0.0.1:${port}`;
+const configuredBaseURL =
+  process.env.CONTRIBUTE_VERIFY_URL ??
+  process.env.PLAYWRIGHT_BASE_URL ??
+  process.env.BASE_URL;
+const port = Number(process.env.BLOCKSTEAD_E2E_PORT ?? 5177);
+const baseURL = configuredBaseURL ?? `http://127.0.0.1:${port}`;
+const webServer = configuredBaseURL
+  ? undefined
+  : {
+      command: `pnpm exec vite --host 127.0.0.1 --port ${port} --strictPort`,
+      url: baseURL,
+      reuseExistingServer: false
+    };
 
 export default defineConfig({
   testDir: "tests/e2e",
   use: {
     baseURL
   },
-  webServer: {
-    command: "pnpm dev -- --host 127.0.0.1",
-    url: baseURL,
-    reuseExistingServer: !process.env.CI
-  },
+  ...(webServer === undefined ? {} : { webServer }),
   projects: [
     {
       name: "chromium",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,22 @@
 import * as THREE from "three";
 
+import { applyActionFeedback } from "./app/actionFeedback";
+import { createHud, toggleCraftingPanel, updateHud, type HudElements } from "./app/hud";
+import {
+  createInputController,
+  nextFrameIntents,
+  type InputController
+} from "./app/inputController";
+import { getLocalStorage, restoreSavedGame, saveGame } from "./app/persistence";
+import { applyPlayerPose, createPlayerCamera } from "./render/camera";
+import { createScene } from "./render/scene";
+import { createWorldRenderer, type WorldRenderer } from "./render/worldRenderer";
+import { BlockId, getBlockDefinition } from "./sim/blocks";
+import { resolveCraft } from "./sim/craftAction";
+import { createHotbar, type Hotbar } from "./sim/hotbar";
+import { addItem, selectHotbarSlot } from "./sim/inventory";
+import { createSimulation, type Simulation } from "./sim/simulation";
+
 export interface AppRenderer {
   readonly domElement: HTMLCanvasElement;
   render(scene: THREE.Scene, camera: THREE.Camera): void;
@@ -7,10 +24,13 @@ export interface AppRenderer {
 }
 
 export interface App {
+  readonly element: HTMLElement;
   readonly scene: THREE.Scene;
   readonly camera: THREE.PerspectiveCamera;
   readonly renderer: AppRenderer;
+  readonly simulation: Simulation;
   step(dt: number): void;
+  dispose(): void;
 }
 
 export type RendererFactory = (canvas?: HTMLCanvasElement) => AppRenderer;
@@ -20,6 +40,8 @@ export interface CreateAppOptions {
   readonly rendererFactory?: RendererFactory;
 }
 
+const CAMERA_EYE_HEIGHT = 1.62;
+
 const createRenderer: RendererFactory = (canvas) =>
   new THREE.WebGLRenderer({
     antialias: true,
@@ -27,18 +49,122 @@ const createRenderer: RendererFactory = (canvas) =>
   });
 
 export function createApp(options: CreateAppOptions = {}): App {
-  const scene = new THREE.Scene();
-  const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 1000);
+  const element = createAppElement();
+  const scene = createScene();
+  const camera = createPlayerCamera();
   const renderer = (options.rendererFactory ?? createRenderer)(options.canvas);
+  const simulation = createSimulation({ seed: 1337 });
+  const storage = getLocalStorage();
+  const loaded = restoreSavedGame(simulation, storage);
+  const worldRenderer = createWorldRenderer(scene, simulation.world);
+  const hotbar = createHotbar(9);
+  const hud = createHud(simulation, hotbar);
+  const input = createInputController(renderer.domElement, {
+    onToggleCrafting: () => toggleCraftingPanel(hud),
+    onSave: () => saveGame(simulation, storage, hud.saveStatus)
+  });
 
-  camera.position.set(0, 1.6, 5);
+  renderer.domElement.dataset.testid = "canvas-host";
+  renderer.domElement.tabIndex = 0;
+  renderer.domElement.style.display = "block";
+  element.append(renderer.domElement, hud.root);
+
+  if (loaded) {
+    hud.saveStatus.setStatus("loaded", "local save");
+    hud.worldStatus.textContent = "Loaded saved world";
+  } else {
+    seedStarterInventory(simulation);
+  }
+
+  hud.craftingPanel.onCraft((recipeId) => {
+    const result = resolveCraft(simulation.inventory, recipeId);
+
+    if (result.ok) {
+      simulation.inventory = selectHotbarSlot(result.inventory, simulation.selectedHotbarSlot);
+      hud.worldStatus.textContent = `Crafted ${getBlockDefinition(result.output.item).name}`;
+    } else {
+      hud.worldStatus.textContent = "Missing recipe inputs";
+    }
+
+    updateHud(hud, simulation, selectedHotbar(hotbar, simulation));
+  });
+
+  worldRenderer.sync();
+  updateCamera(camera, simulation);
+  updateHud(hud, simulation, selectedHotbar(hotbar, simulation));
 
   return {
+    element,
     scene,
     camera,
     renderer,
+    simulation,
     step(dt: number): void {
-      void dt;
+      stepApp(simulation, worldRenderer, hud, hotbar, input, camera, dt);
+    },
+    dispose(): void {
+      input.dispose();
+      worldRenderer.dispose();
     }
+  };
+}
+
+function createAppElement(): HTMLElement {
+  const element = document.createElement("div");
+
+  element.style.position = "fixed";
+  element.style.inset = "0";
+  element.style.overflow = "hidden";
+  element.style.background = "#111827";
+
+  return element;
+}
+
+function stepApp(
+  simulation: Simulation,
+  worldRenderer: WorldRenderer,
+  hud: HudElements,
+  hotbar: Hotbar,
+  input: InputController,
+  camera: THREE.PerspectiveCamera,
+  dt: number
+): void {
+  const frame = nextFrameIntents(input);
+  const beforeInventory = simulation.inventory;
+
+  simulation.step(frame, dt);
+  applyActionFeedback(simulation, hud, frame.actions, beforeInventory);
+  worldRenderer.sync();
+  updateCamera(camera, simulation);
+  updateHud(hud, simulation, selectedHotbar(hotbar, simulation));
+}
+
+function updateCamera(camera: THREE.PerspectiveCamera, simulation: Simulation): void {
+  applyPlayerPose(camera, {
+    position: [
+      simulation.player.position[0],
+      simulation.player.position[1] + CAMERA_EYE_HEIGHT,
+      simulation.player.position[2]
+    ],
+    yaw: simulation.player.yaw,
+    pitch: simulation.player.pitch
+  });
+}
+
+function selectedHotbar(hotbar: Hotbar, simulation: Simulation): Hotbar {
+  return {
+    ...hotbar,
+    selected: simulation.selectedHotbarSlot
+  };
+}
+
+function seedStarterInventory(simulation: Simulation): void {
+  simulation.inventory = addItem(simulation.inventory, BlockId.WOOD, 2).inventory;
+  simulation.inventory = addItem(simulation.inventory, BlockId.DIRT, 6).inventory;
+  simulation.inventory = selectHotbarSlot(simulation.inventory, 0);
+  simulation.selectedHotbarSlot = simulation.inventory.selectedHotbarSlot;
+  simulation.player = {
+    ...simulation.player,
+    selectedHotbarSlot: simulation.selectedHotbarSlot
   };
 }

--- a/src/app/actionFeedback.ts
+++ b/src/app/actionFeedback.ts
@@ -1,0 +1,69 @@
+import type { ActionIntent } from "../input/intents";
+import { BlockId } from "../sim/blocks";
+import { addItem, type Inventory, type InventorySlot } from "../sim/inventory";
+import type { Simulation } from "../sim/simulation";
+import { setBlock } from "../sim/world";
+import type { HudElements } from "./hud";
+
+export function applyActionFeedback(
+  simulation: Simulation,
+  hud: HudElements,
+  actions: ReadonlyArray<ActionIntent>,
+  beforeInventory: Inventory
+): void {
+  for (const action of actions) {
+    if (action.kind === "mine") {
+      if (totalItems(simulation.inventory) === totalItems(beforeInventory)) {
+        simulation.inventory = addItem(simulation.inventory, BlockId.DIRT, 1).inventory;
+      }
+
+      hud.worldStatus.textContent = "Mined block";
+    }
+
+    if (action.kind === "place") {
+      if (selectedCount(simulation.inventory) === selectedCount(beforeInventory)) {
+        placeFallbackBlock(simulation);
+      }
+
+      hud.worldStatus.textContent = "Placed block";
+    }
+  }
+}
+
+function placeFallbackBlock(simulation: Simulation): void {
+  const slot = simulation.inventory.slots[simulation.selectedHotbarSlot];
+
+  if (slot === null || slot.count <= 0) {
+    return;
+  }
+
+  const x = Math.floor(simulation.player.position[0]) + 2;
+  const y = Math.floor(simulation.player.position[1]);
+  const z = Math.floor(simulation.player.position[2]) + 2;
+
+  setBlock(simulation.world, x, y, z, slot.id);
+  simulation.inventory = consumeSelectedSlot(simulation.inventory);
+}
+
+function consumeSelectedSlot(inventory: Inventory): Inventory {
+  const slots = inventory.slots.map((slot, index): InventorySlot | null => {
+    if (index !== inventory.selectedHotbarSlot || slot === null) {
+      return slot === null ? null : { id: slot.id, count: slot.count };
+    }
+
+    return slot.count <= 1 ? null : { id: slot.id, count: slot.count - 1 };
+  });
+
+  return {
+    slots,
+    selectedHotbarSlot: inventory.selectedHotbarSlot
+  };
+}
+
+function totalItems(inventory: Inventory): number {
+  return inventory.slots.reduce((total, slot) => total + (slot?.count ?? 0), 0);
+}
+
+function selectedCount(inventory: Inventory): number {
+  return inventory.slots[inventory.selectedHotbarSlot]?.count ?? 0;
+}

--- a/src/app/actionFeedback.ts
+++ b/src/app/actionFeedback.ts
@@ -1,8 +1,6 @@
 import type { ActionIntent } from "../input/intents";
-import { BlockId } from "../sim/blocks";
-import { addItem, type Inventory, type InventorySlot } from "../sim/inventory";
+import type { Inventory } from "../sim/inventory";
 import type { Simulation } from "../sim/simulation";
-import { setBlock } from "../sim/world";
 import type { HudElements } from "./hud";
 
 export function applyActionFeedback(
@@ -13,51 +11,19 @@ export function applyActionFeedback(
 ): void {
   for (const action of actions) {
     if (action.kind === "mine") {
-      if (totalItems(simulation.inventory) === totalItems(beforeInventory)) {
-        simulation.inventory = addItem(simulation.inventory, BlockId.DIRT, 1).inventory;
-      }
-
-      hud.worldStatus.textContent = "Mined block";
+      hud.worldStatus.textContent =
+        totalItems(simulation.inventory) > totalItems(beforeInventory)
+          ? "Mined block"
+          : "No mineable block in reach";
     }
 
     if (action.kind === "place") {
-      if (selectedCount(simulation.inventory) === selectedCount(beforeInventory)) {
-        placeFallbackBlock(simulation);
-      }
-
-      hud.worldStatus.textContent = "Placed block";
+      hud.worldStatus.textContent =
+        selectedCount(simulation.inventory) < selectedCount(beforeInventory)
+          ? "Placed block"
+          : "Cannot place block";
     }
   }
-}
-
-function placeFallbackBlock(simulation: Simulation): void {
-  const slot = simulation.inventory.slots[simulation.selectedHotbarSlot];
-
-  if (slot === null || slot.count <= 0) {
-    return;
-  }
-
-  const x = Math.floor(simulation.player.position[0]) + 2;
-  const y = Math.floor(simulation.player.position[1]);
-  const z = Math.floor(simulation.player.position[2]) + 2;
-
-  setBlock(simulation.world, x, y, z, slot.id);
-  simulation.inventory = consumeSelectedSlot(simulation.inventory);
-}
-
-function consumeSelectedSlot(inventory: Inventory): Inventory {
-  const slots = inventory.slots.map((slot, index): InventorySlot | null => {
-    if (index !== inventory.selectedHotbarSlot || slot === null) {
-      return slot === null ? null : { id: slot.id, count: slot.count };
-    }
-
-    return slot.count <= 1 ? null : { id: slot.id, count: slot.count - 1 };
-  });
-
-  return {
-    slots,
-    selectedHotbarSlot: inventory.selectedHotbarSlot
-  };
 }
 
 function totalItems(inventory: Inventory): number {

--- a/src/app/hud.ts
+++ b/src/app/hud.ts
@@ -1,0 +1,149 @@
+import { createCoordinatesLabel, type CoordinatesLabel } from "../hud/coordinatesLabel";
+import { createCraftingPanel, type CraftingPanel } from "../hud/craftingPanel";
+import { createHotbarElement, updateHotbarElement } from "../hud/hotbar";
+import { createInventoryPanel, type InventoryPanel } from "../hud/inventoryPanel";
+import { createSaveStatus, type SaveStatusIndicator } from "../hud/saveStatus";
+import type { Hotbar } from "../sim/hotbar";
+import type { Simulation } from "../sim/simulation";
+
+export interface HudElements {
+  readonly root: HTMLElement;
+  readonly hotbarElement: HTMLElement;
+  readonly coordinatesLabel: CoordinatesLabel;
+  readonly inventoryPanel: InventoryPanel;
+  readonly craftingPanel: CraftingPanel;
+  readonly saveStatus: SaveStatusIndicator;
+  readonly worldStatus: HTMLElement;
+}
+
+export function createHud(simulation: Simulation, hotbar: Hotbar): HudElements {
+  const root = document.createElement("div");
+  const coordinatesLabel = createCoordinatesLabel();
+  const inventoryPanel = createInventoryPanel();
+  const craftingPanel = createCraftingPanel();
+  const saveStatus = createSaveStatus();
+  const worldStatus = document.createElement("div");
+  const hotbarElement = createHotbarElement({
+    hotbar,
+    inventory: simulation.inventory
+  });
+
+  root.dataset.testid = "hud-root";
+  root.style.position = "absolute";
+  root.style.inset = "0";
+  root.style.pointerEvents = "none";
+  root.style.color = "#f8fafc";
+  root.style.font = "14px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace";
+  root.style.textShadow = "0 1px 3px rgb(0 0 0 / 0.8)";
+
+  coordinatesLabel.element.style.position = "absolute";
+  coordinatesLabel.element.style.left = "16px";
+  coordinatesLabel.element.style.top = "16px";
+
+  inventoryPanel.element.dataset.testid = "hud-inventory";
+  inventoryPanel.element.style.position = "absolute";
+  inventoryPanel.element.style.right = "16px";
+  inventoryPanel.element.style.top = "16px";
+  inventoryPanel.element.style.minWidth = "140px";
+  inventoryPanel.element.style.padding = "10px";
+  inventoryPanel.element.style.border = "1px solid rgb(255 255 255 / 0.2)";
+  inventoryPanel.element.style.borderRadius = "10px";
+  inventoryPanel.element.style.background = "rgb(15 23 42 / 0.78)";
+
+  craftingPanel.element.dataset.testid = "hud-crafting-panel";
+  craftingPanel.element.style.position = "absolute";
+  craftingPanel.element.style.right = "16px";
+  craftingPanel.element.style.top = "130px";
+  craftingPanel.element.style.display = "none";
+  craftingPanel.element.style.minWidth = "140px";
+  craftingPanel.element.style.padding = "10px";
+  craftingPanel.element.style.border = "1px solid rgb(250 204 21 / 0.5)";
+  craftingPanel.element.style.borderRadius = "10px";
+  craftingPanel.element.style.background = "rgb(15 23 42 / 0.88)";
+  craftingPanel.element.style.pointerEvents = "auto";
+
+  saveStatus.element.style.position = "absolute";
+  saveStatus.element.style.left = "16px";
+  saveStatus.element.style.top = "48px";
+
+  worldStatus.dataset.testid = "hud-world-status";
+  worldStatus.textContent = "Ready";
+  worldStatus.style.position = "absolute";
+  worldStatus.style.left = "16px";
+  worldStatus.style.top = "80px";
+
+  hotbarElement.style.position = "absolute";
+  hotbarElement.style.left = "50%";
+  hotbarElement.style.bottom = "24px";
+  hotbarElement.style.display = "grid";
+  hotbarElement.style.gridTemplateColumns = "repeat(9, 36px)";
+  hotbarElement.style.gap = "4px";
+  hotbarElement.style.transform = "translateX(-50%)";
+
+  root.append(
+    coordinatesLabel.element,
+    inventoryPanel.element,
+    craftingPanel.element,
+    saveStatus.element,
+    worldStatus,
+    hotbarElement
+  );
+  updateHud(
+    {
+      root,
+      hotbarElement,
+      coordinatesLabel,
+      inventoryPanel,
+      craftingPanel,
+      saveStatus,
+      worldStatus
+    },
+    simulation,
+    hotbar
+  );
+
+  return {
+    root,
+    hotbarElement,
+    coordinatesLabel,
+    inventoryPanel,
+    craftingPanel,
+    saveStatus,
+    worldStatus
+  };
+}
+
+export function updateHud(
+  hud: HudElements,
+  simulation: Simulation,
+  hotbar: Hotbar
+): void {
+  const [x, y, z] = simulation.player.position;
+
+  hud.coordinatesLabel.update({ x, y, z });
+  hud.inventoryPanel.update(simulation.inventory);
+  hud.craftingPanel.update(simulation.inventory);
+  updateHotbarElement(hud.hotbarElement, {
+    hotbar,
+    inventory: simulation.inventory
+  });
+
+  for (const child of Array.from(hud.hotbarElement.children)) {
+    if (child instanceof HTMLElement) {
+      styleHotbarSlot(child);
+    }
+  }
+}
+
+export function toggleCraftingPanel(hud: HudElements): void {
+  hud.craftingPanel.element.style.display =
+    hud.craftingPanel.element.style.display === "none" ? "block" : "none";
+}
+
+function styleHotbarSlot(slot: HTMLElement): void {
+  slot.style.width = "36px";
+  slot.style.height = "36px";
+  slot.style.boxSizing = "border-box";
+  slot.style.border = slot.dataset.selected === "true" ? "2px solid #facc15" : "1px solid rgb(255 255 255 / 0.45)";
+  slot.style.background = "rgb(15 23 42 / 0.72)";
+}

--- a/src/app/inputController.ts
+++ b/src/app/inputController.ts
@@ -1,0 +1,148 @@
+import {
+  mineIntent,
+  moveIntent,
+  placeIntent,
+  selectHotbarIntent,
+  type ActionIntent,
+  type IntentAxis,
+  type IntentFrame
+} from "../input/intents";
+
+export interface InputController {
+  readonly pressedKeys: ReadonlySet<string>;
+  drainActions(): ReadonlyArray<ActionIntent>;
+  dispose(): void;
+}
+
+export interface InputActions {
+  onToggleCrafting(): void;
+  onSave(): void;
+}
+
+export function createInputController(
+  canvas: HTMLCanvasElement,
+  actions: InputActions
+): InputController {
+  const pressedKeys = new Set<string>();
+  const pendingActions: ActionIntent[] = [];
+  const view = canvas.ownerDocument.defaultView;
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    pressedKeys.add(event.code);
+    pressedKeys.add(event.key);
+
+    if (event.repeat) {
+      return;
+    }
+
+    const hotbarSlot = readHotbarSlot(event);
+
+    if (hotbarSlot !== null) {
+      event.preventDefault();
+      pendingActions.push(selectHotbarIntent(hotbarSlot));
+      return;
+    }
+
+    if (event.code === "KeyE" || event.key.toLowerCase() === "e") {
+      event.preventDefault();
+      actions.onToggleCrafting();
+      return;
+    }
+
+    if (event.code === "KeyP" || event.key.toLowerCase() === "p") {
+      event.preventDefault();
+      actions.onSave();
+    }
+  }
+
+  function handleKeyUp(event: KeyboardEvent): void {
+    pressedKeys.delete(event.code);
+    pressedKeys.delete(event.key);
+  }
+
+  function handlePointerDown(event: MouseEvent): void {
+    canvas.focus();
+
+    if (event.button === 0) {
+      event.preventDefault();
+      pendingActions.push(mineIntent());
+      return;
+    }
+
+    if (event.button === 2) {
+      event.preventDefault();
+      pendingActions.push(placeIntent());
+    }
+  }
+
+  function handleContextMenu(event: MouseEvent): void {
+    event.preventDefault();
+  }
+
+  canvas.addEventListener("mousedown", handlePointerDown);
+  canvas.addEventListener("contextmenu", handleContextMenu);
+  view?.addEventListener("keydown", handleKeyDown);
+  view?.addEventListener("keyup", handleKeyUp);
+
+  return {
+    pressedKeys,
+    drainActions() {
+      const drained = [...pendingActions];
+      pendingActions.length = 0;
+      return drained;
+    },
+    dispose() {
+      canvas.removeEventListener("mousedown", handlePointerDown);
+      canvas.removeEventListener("contextmenu", handleContextMenu);
+      view?.removeEventListener("keydown", handleKeyDown);
+      view?.removeEventListener("keyup", handleKeyUp);
+    }
+  };
+}
+
+export function nextFrameIntents(input: InputController): IntentFrame {
+  const move = movementIntent(input.pressedKeys);
+
+  return {
+    move,
+    look: null,
+    actions: input.drainActions()
+  };
+}
+
+function movementIntent(pressedKeys: ReadonlySet<string>): IntentFrame["move"] {
+  const forward = axisValue(
+    hasAnyKey(pressedKeys, ["KeyW", "w", "W", "ArrowUp"]),
+    hasAnyKey(pressedKeys, ["KeyS", "s", "S", "ArrowDown"])
+  );
+  const right = axisValue(
+    hasAnyKey(pressedKeys, ["KeyD", "d", "D", "ArrowRight"]),
+    hasAnyKey(pressedKeys, ["KeyA", "a", "A", "ArrowLeft"])
+  );
+
+  return forward === 0 && right === 0 ? null : moveIntent(forward, right, 0, false);
+}
+
+function hasAnyKey(pressedKeys: ReadonlySet<string>, keys: ReadonlyArray<string>): boolean {
+  return keys.some((key) => pressedKeys.has(key));
+}
+
+function axisValue(positive: boolean, negative: boolean): IntentAxis {
+  if (positive === negative) {
+    return 0;
+  }
+
+  return positive ? 1 : -1;
+}
+
+function readHotbarSlot(event: KeyboardEvent): number | null {
+  if (/^Digit[1-9]$/.test(event.code)) {
+    return Number(event.code.slice("Digit".length)) - 1;
+  }
+
+  if (/^[1-9]$/.test(event.key)) {
+    return Number(event.key) - 1;
+  }
+
+  return null;
+}

--- a/src/app/persistence.ts
+++ b/src/app/persistence.ts
@@ -1,0 +1,106 @@
+import type { SaveStatusIndicator } from "../hud/saveStatus";
+import { selectHotbarSlot } from "../sim/inventory";
+import { SAVE_VERSION, type SaveState } from "../sim/save";
+import { loadFromStorage, saveToStorage } from "../sim/saveStorage";
+import type { Simulation } from "../sim/simulation";
+
+const SAVE_KEY = "blockstead:mvp-save";
+
+export function getLocalStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function restoreSavedGame(simulation: Simulation, storage: Storage | null): boolean {
+  if (storage === null) {
+    return false;
+  }
+
+  const loaded = loadFromStorage(SAVE_KEY, storage);
+
+  if (!loaded.ok) {
+    return false;
+  }
+
+  const selectedHotbarSlot = Math.trunc(loaded.state.hotbar.selected);
+
+  simulation.inventory = selectHotbarSlot(
+    {
+      slots: loaded.state.inventory.slots.map((slot) =>
+        slot === null ? null : { id: slot.block, count: slot.count }
+      ),
+      selectedHotbarSlot
+    },
+    selectedHotbarSlot
+  );
+  simulation.selectedHotbarSlot = simulation.inventory.selectedHotbarSlot;
+  simulation.player = {
+    ...simulation.player,
+    position: [
+      loaded.state.player.position[0],
+      loaded.state.player.position[1],
+      loaded.state.player.position[2]
+    ],
+    yaw: loaded.state.player.orientation.yaw,
+    pitch: loaded.state.player.orientation.pitch,
+    selectedHotbarSlot: simulation.selectedHotbarSlot
+  };
+
+  return true;
+}
+
+export function saveGame(
+  simulation: Simulation,
+  storage: Storage | null,
+  saveStatus: SaveStatusIndicator
+): void {
+  if (storage === null) {
+    saveStatus.setStatus("error", "localStorage unavailable");
+    return;
+  }
+
+  saveStatus.setStatus("saving");
+
+  const result = saveToStorage(SAVE_KEY, snapshotGame(simulation), storage);
+
+  if (result.ok) {
+    saveStatus.setStatus("saved", "local save");
+  } else {
+    saveStatus.setStatus("error", "localStorage quota exceeded");
+  }
+}
+
+function snapshotGame(simulation: Simulation): SaveState {
+  return {
+    version: SAVE_VERSION,
+    seed: simulation.seed,
+    mutations: [],
+    player: {
+      position: [
+        simulation.player.position[0],
+        simulation.player.position[1],
+        simulation.player.position[2]
+      ],
+      orientation: {
+        yaw: simulation.player.yaw,
+        pitch: simulation.player.pitch
+      }
+    },
+    inventory: {
+      slots: simulation.inventory.slots.map((slot) =>
+        slot === null
+          ? null
+          : {
+              block: slot.id,
+              count: slot.count
+            }
+      )
+    },
+    hotbar: {
+      selected: simulation.selectedHotbarSlot
+    }
+  };
+}

--- a/src/app/persistence.ts
+++ b/src/app/persistence.ts
@@ -2,7 +2,7 @@ import type { SaveStatusIndicator } from "../hud/saveStatus";
 import { selectHotbarSlot } from "../sim/inventory";
 import { SAVE_VERSION, type SaveState } from "../sim/save";
 import { loadFromStorage, saveToStorage } from "../sim/saveStorage";
-import type { Simulation } from "../sim/simulation";
+import { restoreWorldMutations, type Simulation } from "../sim/simulation";
 
 const SAVE_KEY = "blockstead:mvp-save";
 
@@ -24,6 +24,8 @@ export function restoreSavedGame(simulation: Simulation, storage: Storage | null
   if (!loaded.ok) {
     return false;
   }
+
+  restoreWorldMutations(simulation, loaded.state.mutations);
 
   const selectedHotbarSlot = Math.trunc(loaded.state.hotbar.selected);
 
@@ -77,7 +79,12 @@ function snapshotGame(simulation: Simulation): SaveState {
   return {
     version: SAVE_VERSION,
     seed: simulation.seed,
-    mutations: [],
+    mutations: simulation.mutations.map((mutation) => ({
+      x: mutation.x,
+      y: mutation.y,
+      z: mutation.z,
+      block: mutation.block
+    })),
     player: {
       position: [
         simulation.player.position[0],

--- a/src/hud/craftingPanel.ts
+++ b/src/hud/craftingPanel.ts
@@ -39,29 +39,47 @@ function hasInputs(totals: ReadonlyMap<BlockId, number>, inputs: ReadonlyArray<R
 export function createCraftingPanel(): CraftingPanel {
   const element = document.createElement("div");
   const listeners = new Set<CraftIntentListener>();
+  const rows = new Map<CraftingRecipeId, HTMLElement>();
   let totals: ReadonlyMap<BlockId, number> = new Map<BlockId, number>();
 
   element.dataset.testid = "crafting-panel";
 
   function createRecipeRow(recipeId: CraftingRecipeId): HTMLElement {
-    const recipe = RECIPES[recipeId];
     const row = document.createElement("div");
 
-    row.dataset.recipeId = recipeId;
-    row.dataset.craftable = String(hasInputs(totals, recipe.inputs));
-    row.dataset.requiredInputs = serializeRequiredInputs(recipe.inputs);
-    row.textContent = recipe.id;
     row.addEventListener("click", () => {
       for (const listener of listeners) {
         listener(recipeId);
       }
     });
 
+    updateRecipeRow(row, recipeId);
+
     return row;
   }
 
+  function updateRecipeRow(row: HTMLElement, recipeId: CraftingRecipeId): void {
+    const recipe = RECIPES[recipeId];
+
+    row.dataset.recipeId = recipeId;
+    row.dataset.testid = `craft-recipe-${recipeId}`;
+    row.dataset.craftable = String(hasInputs(totals, recipe.inputs));
+    row.dataset.requiredInputs = serializeRequiredInputs(recipe.inputs);
+    row.textContent = recipe.id;
+  }
+
   function render(): void {
-    element.replaceChildren(...RECIPE_IDS.map((recipeId) => createRecipeRow(recipeId)));
+    for (const recipeId of RECIPE_IDS) {
+      let row = rows.get(recipeId);
+
+      if (row === undefined) {
+        row = createRecipeRow(recipeId);
+        rows.set(recipeId, row);
+        element.append(row);
+      } else {
+        updateRecipeRow(row, recipeId);
+      }
+    }
   }
 
   render();

--- a/src/hud/saveStatus.ts
+++ b/src/hud/saveStatus.ts
@@ -1,4 +1,4 @@
-export type SaveStatusState = "idle" | "saving" | "saved" | "error";
+export type SaveStatusState = "idle" | "saving" | "saved" | "loaded" | "error";
 
 export interface SaveStatusIndicator {
   element: HTMLElement;
@@ -9,6 +9,7 @@ const statusLabels: Record<SaveStatusState, string> = {
   idle: "Idle",
   saving: "Saving...",
   saved: "Saved",
+  loaded: "Loaded",
   error: "Error"
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ if (mount === null) {
 
 const app = createApp();
 
-mount.appendChild(app.renderer.domElement);
+mount.appendChild(app.element);
 
 let lastFrameTime = performance.now();
 

--- a/src/sim/simulation.ts
+++ b/src/sim/simulation.ts
@@ -3,13 +3,15 @@ import { BlockId, getBlockDefinition } from "./blocks";
 import { CHUNK_SIZE } from "./chunk";
 import { addItem, createInventory, selectHotbarSlot, type Inventory, type InventorySlot } from "./inventory";
 import { applyIntent, createPlayer, type Player, type PlayerIntent, type Vec3 } from "./player";
+import type { SaveMutation } from "./save";
 import { generateChunk } from "./terrain";
 import { createWorld, getBlock, setBlock, type ChunkKey, type World } from "./world";
 
 const PLAYER_HALF_WIDTH = 0.3;
 const PLAYER_HEIGHT = 1.8;
 const PLAYER_EYE_HEIGHT = 1.62;
-const SPAWN_Y = 12;
+const SPAWN_SCAN_Y = 12;
+const INITIAL_PITCH = -1.05;
 const REACH_DISTANCE = 5;
 const COLLISION_STEP = 0.25;
 const EPSILON = 0.0001;
@@ -32,6 +34,7 @@ interface RayHit {
 export interface Simulation {
   readonly seed: number;
   world: World;
+  mutations: Array<SaveMutation>;
   player: Player;
   inventory: Inventory;
   selectedHotbarSlot: number;
@@ -42,6 +45,7 @@ export function createSimulation({ seed }: { readonly seed: number }): Simulatio
   const simulation: Simulation = {
     seed,
     world: createWorld(),
+    mutations: [],
     player: createPlayer(),
     inventory: createInventory(),
     selectedHotbarSlot: 0,
@@ -50,10 +54,27 @@ export function createSimulation({ seed }: { readonly seed: number }): Simulatio
     }
   };
 
-  simulation.player.position = [0.5, SPAWN_Y, 0.5];
+  simulation.player.position = [0.5, SPAWN_SCAN_Y, 0.5];
+  simulation.player.pitch = INITIAL_PITCH;
+  ensureChunksForPlayer(simulation);
+  simulation.player.position = [
+    simulation.player.position[0],
+    highestSolidY(simulation, 0, 0) + 2,
+    simulation.player.position[2]
+  ];
   ensureChunksForPlayer(simulation);
 
   return simulation;
+}
+
+function highestSolidY(simulation: Simulation, x: number, z: number): number {
+  for (let y = CHUNK_SIZE - 1; y >= 0; y -= 1) {
+    if (getBlock(simulation.world, x, y, z) !== BlockId.AIR) {
+      return y;
+    }
+  }
+
+  return 0;
 }
 
 function stepSimulation(simulation: Simulation, intents: Readonly<IntentFrame>, dt: number): void {
@@ -130,7 +151,7 @@ function mineTarget(simulation: Simulation): void {
     return;
   }
 
-  setBlock(simulation.world, hit.x, hit.y, hit.z, BlockId.AIR);
+  writeBlock(simulation, hit.x, hit.y, hit.z, BlockId.AIR);
   simulation.inventory = addItem(simulation.inventory, hit.block, 1).inventory;
 }
 
@@ -153,8 +174,54 @@ function placeTarget(simulation: Simulation): void {
     return;
   }
 
-  setBlock(simulation.world, target.x, target.y, target.z, slot.id);
+  writeBlock(simulation, target.x, target.y, target.z, slot.id);
   simulation.inventory = consumeSelectedSlot(simulation.inventory, simulation.selectedHotbarSlot);
+}
+
+export function restoreWorldMutations(
+  simulation: Simulation,
+  mutations: ReadonlyArray<SaveMutation>
+): void {
+  simulation.mutations = [];
+
+  for (const mutation of mutations) {
+    ensureChunkAtVoxel(simulation, mutation.x, mutation.y, mutation.z);
+    setBlock(simulation.world, mutation.x, mutation.y, mutation.z, mutation.block);
+    recordMutation(simulation, mutation);
+  }
+}
+
+function writeBlock(
+  simulation: Simulation,
+  x: number,
+  y: number,
+  z: number,
+  block: BlockId
+): void {
+  setBlock(simulation.world, x, y, z, block);
+  recordMutation(simulation, { x, y, z, block });
+}
+
+function recordMutation(simulation: Simulation, mutation: SaveMutation): void {
+  const existingIndex = simulation.mutations.findIndex(
+    (entry) => entry.x === mutation.x && entry.y === mutation.y && entry.z === mutation.z
+  );
+
+  const nextMutation = {
+    x: mutation.x,
+    y: mutation.y,
+    z: mutation.z,
+    block: mutation.block
+  };
+
+  if (existingIndex === -1) {
+    simulation.mutations = [...simulation.mutations, nextMutation];
+    return;
+  }
+
+  simulation.mutations = simulation.mutations.map((entry, index) =>
+    index === existingIndex ? nextMutation : entry
+  );
 }
 
 function isPlaceable(id: BlockId): boolean {

--- a/tests/app/persistence.test.ts
+++ b/tests/app/persistence.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { restoreSavedGame, saveGame } from "../../src/app/persistence";
+import { BlockId } from "../../src/sim/blocks";
+import { SAVE_VERSION, serializeSave, type SaveState } from "../../src/sim/save";
+import { createSimulation } from "../../src/sim/simulation";
+import { getBlock } from "../../src/sim/world";
+import type { SaveStatusIndicator, SaveStatusState } from "../../src/hud/saveStatus";
+
+const SAVE_KEY = "blockstead:mvp-save";
+
+class MemoryStorage implements Storage {
+  [name: string]: unknown;
+
+  private readonly values = new Map<string, string>();
+
+  public get length(): number {
+    return this.values.size;
+  }
+
+  public clear(): void {
+    this.values.clear();
+  }
+
+  public getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  public key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  public removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  public setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+function createSaveStatus(): SaveStatusIndicator & {
+  readonly states: Array<{ state: SaveStatusState; detail?: string }>;
+} {
+  const states: Array<{ state: SaveStatusState; detail?: string }> = [];
+
+  return {
+    element: document.createElement("div"),
+    states,
+    setStatus(state, detail) {
+      states.push({ state, detail });
+    }
+  };
+}
+
+function makeSaveState(overrides: Partial<SaveState> = {}): SaveState {
+  return {
+    version: SAVE_VERSION,
+    seed: 1337,
+    mutations: [
+      { x: 1, y: 8, z: 1, block: BlockId.AIR },
+      { x: 1, y: 9, z: 1, block: BlockId.DIRT }
+    ],
+    player: {
+      position: [0.5, 12, 0.5],
+      orientation: {
+        yaw: 0,
+        pitch: -1.05
+      }
+    },
+    inventory: {
+      slots: [
+        { block: BlockId.WOOD, count: 1 },
+        { block: BlockId.DIRT, count: 5 }
+      ]
+    },
+    hotbar: {
+      selected: 1
+    },
+    ...overrides
+  };
+}
+
+describe("app persistence", () => {
+  it("restores saved world mutations into generated terrain", () => {
+    const storage = new MemoryStorage();
+    const saved = makeSaveState();
+    const simulation = createSimulation({ seed: 1337 });
+
+    storage.setItem(SAVE_KEY, serializeSave(saved));
+
+    expect(restoreSavedGame(simulation, storage)).toBe(true);
+    expect(getBlock(simulation.world, 1, 8, 1)).toBe(BlockId.AIR);
+    expect(getBlock(simulation.world, 1, 9, 1)).toBe(BlockId.DIRT);
+    expect(simulation.mutations).toEqual(saved.mutations);
+  });
+
+  it("saves current world mutations instead of dropping them", () => {
+    const storage = new MemoryStorage();
+    const saved = makeSaveState({
+      mutations: [{ x: 2, y: 8, z: 2, block: BlockId.PLANKS }]
+    });
+    const simulation = createSimulation({ seed: 1337 });
+    const status = createSaveStatus();
+
+    storage.setItem(SAVE_KEY, serializeSave(saved));
+    restoreSavedGame(simulation, storage);
+    saveGame(simulation, storage, status);
+
+    const raw = storage.getItem(SAVE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw ?? "{}") as SaveState;
+    expect(parsed.mutations).toEqual(saved.mutations);
+    expect(status.states.at(-1)).toEqual({ state: "saved", detail: "local save" });
+  });
+});

--- a/tests/e2e/mvp.spec.ts
+++ b/tests/e2e/mvp.spec.ts
@@ -4,6 +4,24 @@ declare const process: {
   readonly env: Readonly<Record<string, string | undefined>>;
 };
 
+interface SavedMutation {
+  readonly block: number;
+}
+
+async function savedMutationBlocks(page: import("@playwright/test").Page): Promise<number[]> {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem("blockstead:mvp-save");
+
+    if (raw === null) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw) as { mutations?: SavedMutation[] };
+
+    return parsed.mutations?.map((mutation) => mutation.block) ?? [];
+  });
+}
+
 test("satisfies the constitution MVP gameplay loop", async ({ page }) => {
   const runtimeErrors: string[] = [];
 
@@ -47,14 +65,14 @@ test("satisfies the constitution MVP gameplay loop", async ({ page }) => {
     })
     .not.toBe(initialCoordinates);
 
+  await page.mouse.click(400, 300, { button: "left" });
+  await expect(page.locator("[data-testid='hud-world-status']")).toContainText(/mined/i);
+
   await page.keyboard.press("Digit2");
   await expect(page.locator("[data-testid='hud-hotbar-slot-1']")).toHaveAttribute(
     "data-selected",
     "true"
   );
-
-  await page.mouse.click(400, 300, { button: "left" });
-  await expect(page.locator("[data-testid='hud-inventory']")).toContainText(/\d+/);
 
   await page.mouse.click(400, 300, { button: "right" });
   await expect(page.locator("[data-testid='hud-world-status']")).toContainText(/placed/i);
@@ -66,9 +84,16 @@ test("satisfies the constitution MVP gameplay loop", async ({ page }) => {
 
   await page.keyboard.press("KeyP");
   await expect(page.locator("[data-testid='hud-save-status']")).toContainText(/saved/i);
+  await expect.poll(() => savedMutationBlocks(page)).toEqual(
+    expect.arrayContaining([0, 2])
+  );
 
   await page.reload();
   await expect(page.locator("[data-testid='hud-save-status']")).toContainText(/loaded/i);
   await expect(page.locator("[data-testid='hud-inventory']")).toContainText(/planks/i);
+  await page.keyboard.press("KeyP");
+  await expect.poll(() => savedMutationBlocks(page)).toEqual(
+    expect.arrayContaining([0, 2])
+  );
   expect(runtimeErrors).toEqual([]);
 });

--- a/tests/e2e/mvp.spec.ts
+++ b/tests/e2e/mvp.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+
+declare const process: {
+  readonly env: Readonly<Record<string, string | undefined>>;
+};
+
+test("satisfies the constitution MVP gameplay loop", async ({ page }) => {
+  const runtimeErrors: string[] = [];
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      runtimeErrors.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => {
+    runtimeErrors.push(error.message);
+  });
+
+  await page.goto(
+    process.env.BLOCKSTEAD_BASE_URL ??
+      process.env.CONTRIBUTE_VERIFY_URL ??
+      process.env.PLAYWRIGHT_BASE_URL ??
+      process.env.BASE_URL ??
+      "/"
+  );
+  await page.evaluate(() => {
+    localStorage.removeItem("blockstead:mvp-save");
+  });
+  await page.reload();
+
+  await expect(page.locator("[data-testid='canvas-host']")).toBeVisible();
+  await expect(page.locator("[data-testid='hud-root']")).toBeVisible();
+  await expect(page.locator("[data-testid='hud-hotbar']")).toBeVisible();
+
+  const coordinates = page.locator("[data-testid='hud-coordinates']");
+  await expect(coordinates).toBeVisible();
+  const initialCoordinates = await coordinates.textContent();
+
+  await page.keyboard.down("KeyW");
+  await page.waitForTimeout(750);
+  await page.keyboard.up("KeyW");
+
+  await expect
+    .poll(() => coordinates.textContent(), {
+      message: "player coordinates should change after holding W",
+      timeout: 2_000
+    })
+    .not.toBe(initialCoordinates);
+
+  await page.keyboard.press("Digit2");
+  await expect(page.locator("[data-testid='hud-hotbar-slot-1']")).toHaveAttribute(
+    "data-selected",
+    "true"
+  );
+
+  await page.mouse.click(400, 300, { button: "left" });
+  await expect(page.locator("[data-testid='hud-inventory']")).toContainText(/\d+/);
+
+  await page.mouse.click(400, 300, { button: "right" });
+  await expect(page.locator("[data-testid='hud-world-status']")).toContainText(/placed/i);
+
+  await page.keyboard.press("KeyE");
+  await expect(page.locator("[data-testid='hud-crafting-panel']")).toBeVisible();
+  await page.locator("[data-testid='craft-recipe-planks']").click();
+  await expect(page.locator("[data-testid='hud-inventory']")).toContainText(/planks/i);
+
+  await page.keyboard.press("KeyP");
+  await expect(page.locator("[data-testid='hud-save-status']")).toContainText(/saved/i);
+
+  await page.reload();
+  await expect(page.locator("[data-testid='hud-save-status']")).toContainText(/loaded/i);
+  await expect(page.locator("[data-testid='hud-inventory']")).toContainText(/planks/i);
+  expect(runtimeErrors).toEqual([]);
+});

--- a/tests/hud/saveStatus.test.ts
+++ b/tests/hud/saveStatus.test.ts
@@ -6,6 +6,7 @@ const transitions: Array<[SaveStatusState, string]> = [
   ["idle", "Idle"],
   ["saving", "Saving..."],
   ["saved", "Saved"],
+  ["loaded", "Loaded"],
   ["error", "Error"]
 ];
 

--- a/tests/sim/simulation.test.ts
+++ b/tests/sim/simulation.test.ts
@@ -43,6 +43,9 @@ describe("simulation aggregate", () => {
 
     expect(getBlock(simulation.world, target.x, target.y, target.z)).toBe(BlockId.AIR);
     expect(simulation.inventory.slots[0]).toEqual({ id: BlockId.STONE, count: 1 });
+    expect(simulation.mutations).toEqual([
+      { x: target.x, y: target.y, z: target.z, block: BlockId.AIR }
+    ]);
   });
 
   it("places a selected hotbar block into targeted air and consumes one item", () => {
@@ -59,5 +62,8 @@ describe("simulation aggregate", () => {
 
     expect(getBlock(simulation.world, target.x, target.y, target.z)).toBe(BlockId.DIRT);
     expect(simulation.inventory.slots[0]).toEqual({ id: BlockId.DIRT, count: 1 });
+    expect(simulation.mutations).toEqual([
+      { x: target.x, y: target.y, z: target.z, block: BlockId.DIRT }
+    ]);
   });
 });

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -12,10 +12,25 @@ function createTestRenderer(): AppRenderer {
 }
 
 describe("createApp", () => {
-  it("creates the Three.js bootstrap objects", () => {
+  it("creates the Three.js bootstrap objects and visible shell", () => {
     const app = createApp({ rendererFactory: createTestRenderer });
 
     expect(app.scene).toBeInstanceOf(THREE.Scene);
     expect(app.camera).toBeInstanceOf(THREE.PerspectiveCamera);
+    expect(Array.from(app.element.children)).toContain(app.renderer.domElement);
+    expect(app.renderer.domElement.dataset.testid).toBe("canvas-host");
+    expect(app.element.querySelector('[data-testid="hud-root"]')).toBeInstanceOf(
+      HTMLElement
+    );
+  });
+
+  it("renders generated terrain instead of an empty black scene", () => {
+    const app = createApp({ rendererFactory: createTestRenderer });
+    const terrainMeshes = app.scene.children.filter(
+      (child): child is THREE.Mesh => child instanceof THREE.Mesh
+    );
+
+    expect(app.scene.background).toBeInstanceOf(THREE.Color);
+    expect(terrainMeshes.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Supersedes #271 with the review fixes applied.

Changes:
- Removes fake mine/place state fallbacks from HUD action feedback.
- Records real simulation block mutations during mine/place and persists/restores them through localStorage.
- Spawns the player relative to generated terrain with a default downward pitch so the initial MVP loop can target blocks.
- Tightens the MVP Playwright gate to require real mine/place feedback and saved AIR/DIRT mutations after reload.

Validation:
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm build
- BLOCKSTEAD_E2E_PORT=5190 pnpm exec playwright test tests/e2e/mvp.spec.ts