### PR TITLE
test: Implement src/input/index.ts re-exports and replace tests/input/index.test.ts todo

### DIFF
--- a/src/input/index.ts
+++ b/src/input/index.ts
@@ -1,8 +1,8 @@
 // Input adapters must not import from src/sim or src/render.
 // This layer translates browser events into deterministic intent objects only.
 
-// export * from './keyboard';
-// export * from './mouse';
-// export * from './pointerLock';
-
-export {};
+export * from "./hotbarKeys";
+export * from "./intents";
+export * from "./keyboard";
+export * from "./mouse";
+export * from "./pointerLock";

--- a/tests/input/index.test.ts
+++ b/tests/input/index.test.ts
@@ -1,5 +1,42 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-describe('input module', () => {
-  it.todo('adapts keyboard and mouse events into deterministic intents');
+import {
+  EMPTY_INTENT_FRAME,
+  createHotbarKeysAdapter,
+  createKeyboardAdapter,
+  createMouseAdapter,
+  createPointerLock,
+  lookIntent,
+  mineIntent,
+  moveIntent,
+  placeIntent,
+  saveIntent,
+  selectHotbarIntent,
+  toggleInventoryIntent,
+  type Intent,
+  type IntentFrame
+} from "../../src/input";
+
+describe("input module", () => {
+  it("re-exports adapter factories from the barrel", () => {
+    expect(createKeyboardAdapter).toEqual(expect.any(Function));
+    expect(createMouseAdapter).toEqual(expect.any(Function));
+    expect(createPointerLock).toEqual(expect.any(Function));
+    expect(createHotbarKeysAdapter).toEqual(expect.any(Function));
+  });
+
+  it("re-exports intent helpers from the barrel", () => {
+    const move: Intent = moveIntent(1, 0, -1, true);
+    const look: Intent = lookIntent(2, -3);
+    const frame: IntentFrame = EMPTY_INTENT_FRAME;
+
+    expect(move).toEqual({ kind: "move", forward: 1, right: 0, up: -1, jump: true });
+    expect(look).toEqual({ kind: "look", yawDelta: 2, pitchDelta: -3 });
+    expect(mineIntent()).toEqual({ kind: "mine" });
+    expect(placeIntent()).toEqual({ kind: "place" });
+    expect(selectHotbarIntent(4)).toEqual({ kind: "selectHotbar", slot: 4 });
+    expect(toggleInventoryIntent()).toEqual({ kind: "toggleInventory" });
+    expect(saveIntent()).toEqual({ kind: "save" });
+    expect(frame).toEqual({ move: null, look: null, actions: [] });
+  });
 });


### PR DESCRIPTION
## Implement src/input/index.ts re-exports and replace tests/input/index.test.ts todo

**Category:** `test` | **Contributor:** imJ0swgQO8unfwOZepBFm

Closes #284

### Changes
Update src/input/index.ts to re-export the public surface from sibling modules — at minimum createKeyboardAdapter from keyboard.ts, createMouseAdapter from mouse.ts, createPointerLock from pointerLock.ts, intent helpers/types from intents.ts, and the hotbar key helpers from hotbarKeys.ts. Then replace the it.todo stub in tests/input/index.test.ts with real assertions that import directly from '../../src/input' (the barrel) and verify the keyboard, mouse, and pointerLock adapter factories are exported as functions, plus that intent helpers are present. Do NOT modify the underlying adapter modules — only barrel re-exports and assertions.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*