### PR TITLE
docs: Add Controls reference and MVP Limitations sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,32 @@ pnpm build
 - `E`: toggle inventory intent
 - `P`: save intent
 
+Reference table:
+
+| Action | Key/Button | Notes |
+| --- | --- | --- |
+| Move forward | `KeyW` (`W`) or `ArrowUp` | From `DEFAULT_BINDINGS`; part of WASD and arrow-key movement. |
+| Move backward | `KeyS` (`S`) or `ArrowDown` | From `DEFAULT_BINDINGS`; part of WASD and arrow-key movement. |
+| Move left | `KeyA` (`A`) or `ArrowLeft` | From `DEFAULT_BINDINGS`; part of WASD and arrow-key movement. |
+| Move right | `KeyD` (`D`) or `ArrowRight` | From `DEFAULT_BINDINGS`; part of WASD and arrow-key movement. |
+| Jump | `Space` | Emits jump through the movement intent. |
+| Toggle inventory | `KeyE` (`E`) | Bound to the inventory/crafting toggle intent. |
+| Save | `KeyP` (`P`) | Source binds `KeyP`; `Ctrl+S` is not currently bound. |
+| Select hotbar slot | `Digit1` through `Digit9` | Selects hotbar slots 1-9; modified and repeated digit presses are ignored by the hotbar adapter. |
+| Mine | Left mouse button (`button === 0`) | Mouse button events emit mine intent. |
+| Place | Right mouse button (`button === 2`) | Mouse button events emit place intent. |
+| Lock pointer | Click the canvas/target | The pointer-lock adapter requests pointer lock on click. |
+| Look | Mouse movement | Mouse movement emits look intent; pointer-lock look deltas are emitted only while locked. |
+
+## MVP Limitations
+
+- New games default to deterministic seed `1337`.
+- Saves use a single `localStorage` slot (`blockstead:mvp-save`); there is no save management UI, and saving overwrites the current slot.
+- There is no day/night cycle.
+- There is no audio.
+- Terrain is currently a single biome.
+- Browser focus loss is a known input edge case: if the window loses focus while keys are held, input state may not be released cleanly.
+
 ## Current Scope
 
 The repository contains the core TypeScript/Vite project structure plus tested simulation, rendering, input, HUD, inventory, crafting, save/load, terrain, and world modules.


### PR DESCRIPTION
## Add Controls reference and MVP Limitations sections to README

**Category:** `docs` | **Contributor:** rc5aXQArXebGxCxzFJJ24

Closes #292

### Changes
Extend the existing README.md with two new sections: (1) a 'Controls' section that lists every input binding the player uses, sourced verbatim from src/input/keyboard.ts (DEFAULT_BINDINGS for WASD movement, Space jump, E for crafting/inventory toggle, Ctrl+S or whichever save key is bound), src/input/hotbarKeys.ts (Digit1-Digit9 select hotbar slots 1-9), and src/input/mouse.ts / src/input/pointerLock.ts (left mouse mine, right mouse place, click-to-lock pointer, mouse look). Present this as a markdown table with columns: Action, Key/Button, Notes. (2) An 'MVP Limitations' section that explicitly calls out: deterministic seed defaulting to 1337, single localStorage save slot (no save management UI, overwritten on save), no day/night cycle, no audio, single biome only, and known browser focus-loss behavior (input state may not be released cleanly when the window loses focus while keys are held). Read the actual key bindings from src/input/keyboard.ts and src/input/hotbarKeys.ts before writing — do not guess. If a binding listed in the proposal is not present in source, document what is actually bound and note the discrepancy in a constraints-respecting way (do not invent bindings). Place the new sections after any existing setup/install/test-commands content; do not remove or reorder existing README content. Do not modify any source files — README only.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*