### PR TITLE
test: Add chunk mesh dirty-tracking test for worldRenderer.sync

### DIFF
--- a/tests/render/worldRenderer.test.ts
+++ b/tests/render/worldRenderer.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createWorldRenderer } from "../../src/render/worldRenderer";
 import { BlockId } from "../../src/sim/blocks";
 import { CHUNK_SIZE } from "../../src/sim/chunk";
+import { createSimulation } from "../../src/sim/simulation";
 import { createWorld, setBlock, type ChunkKey, type World } from "../../src/sim/world";
 
 describe("createWorldRenderer", () => {
@@ -52,6 +53,38 @@ describe("createWorldRenderer", () => {
     expect(dirtyGeometryDispose).toHaveBeenCalledTimes(1);
     expect(getMeshForChunk(scene, stableKey)).toBe(stableMesh);
     expect(stableMesh.geometry).toBe(stableGeometry);
+
+    renderer.dispose();
+  });
+
+  it("preserves unaffected simulation chunk mesh geometry after a dirty sync", () => {
+    const scene = new THREE.Scene();
+    const simulation = createSimulation({ seed: 1337 });
+    const renderer = createWorldRenderer(scene, simulation.world);
+
+    const dirtyKey: ChunkKey = "0,0,0";
+    const stableKey: ChunkKey = "1,0,0";
+
+    setBlock(simulation.world, 2, 2, 3, BlockId.STONE);
+    setBlock(simulation.world, CHUNK_SIZE + 1, 2, 3, BlockId.DIRT);
+    renderer.sync();
+
+    const dirtyMesh = getMeshForChunk(scene, dirtyKey);
+    const stableMesh = getMeshForChunk(scene, stableKey);
+    const dirtyGeometry = dirtyMesh.geometry;
+    const stableGeometry = stableMesh.geometry;
+    const dirtyGeometryDispose = vi.spyOn(dirtyGeometry, "dispose");
+    const stableGeometryDispose = vi.spyOn(stableGeometry, "dispose");
+
+    setBlock(simulation.world, 2, 2, 3, BlockId.DIRT);
+    renderer.sync();
+
+    expect(getMeshForChunk(scene, dirtyKey)).toBe(dirtyMesh);
+    expect(dirtyMesh.geometry).not.toBe(dirtyGeometry);
+    expect(dirtyGeometryDispose).toHaveBeenCalledTimes(1);
+    expect(getMeshForChunk(scene, stableKey)).toBe(stableMesh);
+    expect(stableMesh.geometry).toBe(stableGeometry);
+    expect(stableGeometryDispose).not.toHaveBeenCalled();
 
     renderer.dispose();
   });


### PR DESCRIPTION
## Add chunk mesh dirty-tracking test for worldRenderer.sync

**Category:** `test` | **Contributor:** mKTULZ0_sanFPkt5TfIWL

Closes #287

### Changes
Extend tests/render/worldRenderer.test.ts with a new test case that exercises the dirty-tracking performance guard end-to-end via the simulation surface. The test should: (1) construct a THREE.Scene plus a seeded simulation via createSimulation (or create a populated world covering at least two distinct chunk keys so unaffected chunks can be verified); (2) call createWorldRenderer(scene, simulation.world) and renderer.sync() once to populate meshes; (3) capture the mesh objects (and their geometries) for an 'affected' chunk and at least one 'unaffected' chunk by ChunkKey; (4) mutate a single voxel inside the affected chunk via setBlock on simulation.world (or simulation.world directly); (5) call renderer.sync() again; (6) assert that the unaffected chunk's mesh and its geometry are the SAME object identity as before (i.e. not rebuilt), while the affected chunk's geometry was rebuilt — either by checking geometry object identity changed (or its dispose was called) for the dirty chunk, or by spying on buildChunkMesh/the mesh's geometry.dispose to confirm exactly one rebuild happened and only on the dirty chunk. Use vi.spyOn where appropriate, and reuse helpers already defined in the file (getMeshForChunk, getChunkKeys, getSceneMeshes). The new test must coexist with — not replace — the existing 'rebuilds only the mutated chunk mesh geometry' test, and should make the assertion stronger by adding the unaffected-chunk identity check and/or a build-call counter so a regression to full-world recomputation will fail. Do not modify production code; this test must pass against the current implementation.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*