### PR TITLE
test: Add tests for corrupted save data, quota errors, and missing localStorage

### DIFF
--- a/tests/sim/save.test.ts
+++ b/tests/sim/save.test.ts
@@ -65,6 +65,34 @@ describe("save codec", () => {
     });
   });
 
+  it("returns the typed invalid_json failure for unparseable save data", () => {
+    expect(deserializeSave("{not json")).toEqual({
+      ok: false,
+      error: {
+        kind: "invalid_json",
+        message: "Save data is not valid JSON."
+      }
+    });
+  });
+
+  it("returns the typed version_mismatch failure for unsupported save versions", () => {
+    const actualVersion = SAVE_VERSION + 2;
+    const payload = {
+      ...baseState,
+      version: actualVersion
+    };
+
+    expect(deserializeSave(JSON.stringify(payload))).toEqual({
+      ok: false,
+      error: {
+        kind: "version_mismatch",
+        message: `Unsupported save version ${actualVersion}; expected ${SAVE_VERSION}.`,
+        expected: SAVE_VERSION,
+        actual: actualVersion
+      }
+    });
+  });
+
   it("returns invalid_shape for missing or wrong-typed fields", () => {
     expect(deserializeSave(JSON.stringify({ ...baseState, seed: "12345" }))).toMatchObject({
       ok: false,
@@ -87,6 +115,53 @@ describe("save codec", () => {
       ok: false,
       error: { kind: "invalid_shape" }
     });
+  });
+
+  it("returns invalid_shape when required top-level fields are missing", () => {
+    const requiredFields = ["seed", "mutations", "player", "inventory", "hotbar"] as const;
+
+    for (const field of requiredFields) {
+      const payload: Partial<SaveState> = { ...baseState };
+
+      delete payload[field];
+
+      expect(deserializeSave(JSON.stringify(payload))).toEqual({
+        ok: false,
+        error: {
+          kind: "invalid_shape",
+          message: "Save data does not match the expected save schema."
+        }
+      });
+    }
+  });
+
+  it("returns invalid_shape for wrong nested save types", () => {
+    const malformedPayloads: Array<Record<string, unknown>> = [
+      { ...baseState, mutations: "not-an-array" },
+      {
+        ...baseState,
+        player: {
+          ...baseState.player,
+          position: [1, 2]
+        }
+      },
+      {
+        ...baseState,
+        inventory: {
+          slots: [{ block: BlockId.DIRT, count: "negative-one" }]
+        }
+      }
+    ];
+
+    for (const payload of malformedPayloads) {
+      expect(deserializeSave(JSON.stringify(payload))).toEqual({
+        ok: false,
+        error: {
+          kind: "invalid_shape",
+          message: "Save data does not match the expected save schema."
+        }
+      });
+    }
   });
 
   it("keeps sparse mutation payloads sparse", () => {

--- a/tests/sim/saveStorage.test.ts
+++ b/tests/sim/saveStorage.test.ts
@@ -91,6 +91,31 @@ describe("save storage", () => {
     expect(loadFromStorage("bad-shape", storage)).toEqual({ ok: false, error: "malformed" });
   });
 
+  it("returns malformed when stored save JSON is not parseable", () => {
+    const storage = new MemoryStorage();
+
+    storage.setItem("save", "{not json");
+
+    expect(loadFromStorage("save", storage)).toEqual({ ok: false, error: "malformed" });
+  });
+
+  it("returns malformed when stored save JSON has an invalid schema", () => {
+    const storage = new MemoryStorage();
+
+    storage.setItem(
+      "save",
+      JSON.stringify({
+        ...baseState,
+        player: {
+          ...baseState.player,
+          position: [1, 2]
+        }
+      })
+    );
+
+    expect(loadFromStorage("save", storage)).toEqual({ ok: false, error: "malformed" });
+  });
+
   it("returns quota_exceeded when storage quota is exceeded", () => {
     const storage = new MemoryStorage();
 
@@ -100,5 +125,27 @@ describe("save storage", () => {
       ok: false,
       error: "quota_exceeded"
     });
+  });
+
+  it("returns quota_exceeded when setItem throws a quota DOMException", () => {
+    const storage = new MemoryStorage();
+
+    storage.setError = new DOMException("Storage quota exceeded.", "QuotaExceededError");
+
+    expect(saveToStorage("save", baseState, storage)).toEqual({
+      ok: false,
+      error: "quota_exceeded"
+    });
+  });
+
+  it("throws when called without a storage object", () => {
+    const missingStorageValues = [undefined, null] as const;
+
+    for (const storage of missingStorageValues) {
+      expect(() => loadFromStorage("save", storage as unknown as Storage)).toThrow(TypeError);
+      expect(() => saveToStorage("save", baseState, storage as unknown as Storage)).toThrow(
+        TypeError
+      );
+    }
   });
 });


### PR DESCRIPTION
## Add tests for corrupted save data, quota errors, and missing localStorage

**Category:** `test` | **Contributor:** RF9ciq3FK76nUtda0qDW0

Closes #275

### Changes
Extend the existing persistence tests to cover documented failure modes of the EXISTING save/load layer in src/sim/save.ts and src/sim/saveStorage.ts. Read both source modules first to understand their actual return contract — these tests must pass against current code, not drive new behavior. Add tests to tests/sim/save.test.ts that exercise deserializeSave with: (1) malformed JSON that is not parseable, (2) JSON that parses but is missing required top-level fields (e.g. seed, mutations, player, inventory, hotbar), (3) JSON whose nested types are wrong (e.g. mutations not an array, player.position not a 3-tuple of numbers, inventory.slots entries with negative counts), and (4) the existing version-mismatch case if not already covered. Each test must assert the typed failure shape that deserializeSave actually returns (e.g. { ok: false, ... }) rather than expecting a thrown error, unless the source code throws — match the real contract. Add tests to tests/sim/saveStorage.test.ts that exercise loadFromStorage and saveToStorage with: (a) the existing MemoryStorage holding malformed JSON under the save key — load must return the typed failure / null contract from the source, (b) MemoryStorage holding a payload that is valid JSON but schema-mismatched — load must surface the same typed failure, (c) saveToStorage when the underlying Storage.setItem throws a quota-exceeded-style DOMException (use the existing MemoryStorage.setError hook) — save must surface a recoverable result rather than throw, and (d) load and save when the storage argument is undefined / null (simulating an environment with no window.localStorage) — both must return the documented no-storage outcome without throwing. Reuse the existing MemoryStorage class and baseState fixture in saveStorage.test.ts; do not duplicate them. Do not modify any source files under src/.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*