### PR TITLE
test: Add unit tests for src/app/actionFeedback.ts

### DIFF
--- a/tests/app/actionFeedback.test.ts
+++ b/tests/app/actionFeedback.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { applyActionFeedback } from "../../src/app/actionFeedback";
+import { mineIntent, placeIntent } from "../../src/input/intents";
+import { BlockId } from "../../src/sim/blocks";
+import { addItem, type Inventory } from "../../src/sim/inventory";
+import { createSimulation } from "../../src/sim/simulation";
+import { setBlock } from "../../src/sim/world";
+import type { HudElements } from "../../src/app/hud";
+
+function createHud(textContent = "Ready"): HudElements {
+  return {
+    worldStatus: { textContent }
+  } as unknown as HudElements;
+}
+
+function cloneInventory(inventory: Inventory): Inventory {
+  return {
+    slots: inventory.slots.map((slot) =>
+      slot === null ? null : { id: slot.id, count: slot.count }
+    ),
+    selectedHotbarSlot: inventory.selectedHotbarSlot
+  };
+}
+
+describe("applyActionFeedback", () => {
+  it("reports a mined block when a mine action increases total inventory items", () => {
+    const simulation = createSimulation({ seed: 333 });
+    const hud = createHud();
+    const actions = [mineIntent()];
+    const target = { x: 0, y: 13, z: 3 };
+
+    simulation.player = { ...simulation.player, position: [0.5, 12, 0.5], yaw: 0, pitch: 0 };
+    setBlock(simulation.world, target.x, target.y, target.z, BlockId.STONE);
+    const beforeInventory = cloneInventory(simulation.inventory);
+
+    simulation.step({ move: null, look: null, actions }, 0);
+    applyActionFeedback(simulation, hud, actions, beforeInventory);
+
+    expect(hud.worldStatus.textContent).toBe("Mined block");
+  });
+
+  it("reports no mineable block when a mine action does not increase total inventory items", () => {
+    const simulation = createSimulation({ seed: 334 });
+    const hud = createHud();
+    const beforeInventory = cloneInventory(simulation.inventory);
+
+    applyActionFeedback(simulation, hud, [mineIntent()], beforeInventory);
+
+    expect(hud.worldStatus.textContent).toBe("No mineable block in reach");
+  });
+
+  it("reports a placed block when a place action decreases the selected hotbar slot count", () => {
+    const simulation = createSimulation({ seed: 444 });
+    const hud = createHud();
+    const actions = [placeIntent()];
+    const support = { x: 0, y: 13, z: 3 };
+    const target = { x: 0, y: 13, z: 2 };
+
+    simulation.player = { ...simulation.player, position: [0.5, 12, 0.5], yaw: 0, pitch: 0 };
+    simulation.inventory = addItem(simulation.inventory, BlockId.DIRT, 2).inventory;
+    setBlock(simulation.world, support.x, support.y, support.z, BlockId.STONE);
+    setBlock(simulation.world, target.x, target.y, target.z, BlockId.AIR);
+    const beforeInventory = cloneInventory(simulation.inventory);
+
+    simulation.step({ move: null, look: null, actions }, 0);
+    applyActionFeedback(simulation, hud, actions, beforeInventory);
+
+    expect(hud.worldStatus.textContent).toBe("Placed block");
+  });
+
+  it("reports a failed placement when a place action does not decrease the selected hotbar slot count", () => {
+    const simulation = createSimulation({ seed: 445 });
+    const hud = createHud();
+
+    simulation.inventory = addItem(simulation.inventory, BlockId.DIRT, 2).inventory;
+    const beforeInventory = cloneInventory(simulation.inventory);
+
+    applyActionFeedback(simulation, hud, [placeIntent()], beforeInventory);
+
+    expect(hud.worldStatus.textContent).toBe("Cannot place block");
+  });
+
+  it("leaves the world status unchanged when there are no actions", () => {
+    const simulation = createSimulation({ seed: 446 });
+    const hud = createHud("Already set");
+    const beforeInventory = cloneInventory(simulation.inventory);
+
+    applyActionFeedback(simulation, hud, [], beforeInventory);
+
+    expect(hud.worldStatus.textContent).toBe("Already set");
+  });
+});


### PR DESCRIPTION
## Add unit tests for src/app/actionFeedback.ts

**Category:** `test` | **Contributor:** RF9ciq3FK76nUtda0qDW0

Closes #299

### Changes
Create tests/app/actionFeedback.test.ts that exercises applyActionFeedback for the three branches it currently leaves uncovered: (1) a successful mine action increases total inventory items and the worldStatus textContent becomes 'Mined block'; (2) a mine action that does not increase the inventory total leaves textContent as 'No mineable block in reach'; (3) a successful place action decreases the selected hotbar slot count and textContent becomes 'Placed block'; (4) a place action that does not decrease the selected slot count yields 'Cannot place block'; (5) when actions is an empty array the worldStatus textContent is left exactly as it was before the call (no-op). Use a fake HudElements where worldStatus is a plain object exposing a mutable textContent string property — only that property is read by applyActionFeedback, so a typed minimal stub (cast through `as unknown as HudElements`) is acceptable; do not stand up a full DOM. Build Simulation fixtures via createSimulation({ seed }) from src/sim/simulation.ts, then drive the inventory deltas either by stepping the real simulation (mirroring the mine pattern in tests/sim/simulation.test.ts where setBlock + a player position + step({ actions: [{ kind: 'mine' }] }) yields a deterministic drop) OR by passing a hand-constructed beforeInventory snapshot whose totals/selected counts intentionally differ from simulation.inventory in the way the branch under test requires. Capture beforeInventory by deep-cloning simulation.inventory.slots before the mutation. Use the action constructors from src/input/intents.ts (e.g. mineIntent(), placeIntent()) where applicable, but note that applyActionFeedback receives ActionIntent values typed as { kind: 'mine' } | { kind: 'place' }, so passing `[{ kind: 'mine' }]` literals is also fine. Assert against hud.worldStatus.textContent after the call.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*