### PR TITLE
test: Add save serialization v1 fixture and regression test

### DIFF
--- a/tests/sim/fixtures/save-v1.json
+++ b/tests/sim/fixtures/save-v1.json
@@ -1,0 +1,1 @@
+{"version":1,"seed":42,"mutations":[{"x":0,"y":8,"z":0,"block":2},{"x":1,"y":9,"z":-2,"block":0},{"x":-3,"y":10,"z":4,"block":8},{"x":16,"y":7,"z":-16,"block":3}],"player":{"position":[12.5,14.25,-6.75],"orientation":{"yaw":0.875,"pitch":-0.375}},"inventory":{"slots":[{"block":2,"count":32},null,{"block":8,"count":6},{"block":3,"count":14},null]},"hotbar":{"selected":3}}

--- a/tests/sim/saveRegression.test.ts
+++ b/tests/sim/saveRegression.test.ts
@@ -1,0 +1,113 @@
+declare const process: {
+  readonly env: Readonly<Record<string, string | undefined>>;
+  cwd(): string;
+};
+
+import { describe, expect, it } from "vitest";
+
+import { BlockId } from "../../src/sim/blocks";
+import {
+  deserializeSave,
+  SAVE_VERSION,
+  serializeSave,
+  type SaveState
+} from "../../src/sim/save";
+
+// If this test fails after intentional save-format changes, regenerate the fixture by running
+// `UPDATE_SAVE_V1_FIXTURE=1 pnpm vitest run tests/sim/saveRegression.test.ts`
+// and review the diff carefully - any change here is a save-format break for existing players.
+
+interface FileSystemModule {
+  readonly mkdirSync: (path: string, options: { readonly recursive: boolean }) => void;
+  readonly readFileSync: (path: string, encoding: "utf8") => string;
+  readonly writeFileSync: (path: string, data: string, encoding: "utf8") => void;
+}
+
+const NODE_FS: string = "node:fs";
+const fs = (await import(NODE_FS)) as FileSystemModule;
+const FIXTURE_DIRECTORY = `${process.cwd()}/tests/sim/fixtures`;
+const FIXTURE_PATH = `${FIXTURE_DIRECTORY}/save-v1.json`;
+const UPDATE_FIXTURE = process.env.UPDATE_SAVE_V1_FIXTURE === "1";
+
+const canonicalState: SaveState = {
+  version: SAVE_VERSION,
+  seed: 42,
+  mutations: [
+    { x: 0, y: 8, z: 0, block: BlockId.DIRT },
+    { x: 1, y: 9, z: -2, block: BlockId.AIR },
+    { x: -3, y: 10, z: 4, block: BlockId.TORCH },
+    { x: 16, y: 7, z: -16, block: BlockId.STONE }
+  ],
+  player: {
+    position: [12.5, 14.25, -6.75],
+    orientation: {
+      yaw: 0.875,
+      pitch: -0.375
+    }
+  },
+  inventory: {
+    slots: [
+      { block: BlockId.DIRT, count: 32 },
+      null,
+      { block: BlockId.TORCH, count: 6 },
+      { block: BlockId.STONE, count: 14 },
+      null
+    ]
+  },
+  hotbar: {
+    selected: 3
+  }
+};
+
+const serializedCanonicalState = serializeSave(canonicalState);
+
+if (UPDATE_FIXTURE) {
+  fs.mkdirSync(FIXTURE_DIRECTORY, { recursive: true });
+  fs.writeFileSync(FIXTURE_PATH, serializedCanonicalState, "utf8");
+}
+
+const fixtureContents = fs.readFileSync(FIXTURE_PATH, "utf8");
+
+describe("save v1 regression fixture", () => {
+  it("matches the canonical serialized save state byte-for-byte", () => {
+    expect(canonicalState.version).toBe(SAVE_VERSION);
+    expect(canonicalState.seed).toBe(42);
+
+    if (UPDATE_FIXTURE) {
+      return;
+    }
+
+    expect(serializedCanonicalState).toBe(fixtureContents);
+  });
+
+  it("deserializes and reserializes the fixture byte-for-byte", () => {
+    const result = deserializeSave(fixtureContents);
+
+    expect(result.ok).toBe(true);
+
+    if (!result.ok) {
+      throw new Error(result.error.message);
+    }
+
+    if (UPDATE_FIXTURE) {
+      return;
+    }
+
+    expect(serializeSave(result.state)).toBe(fixtureContents);
+  });
+
+  it("rejects empty and non-object save payloads", () => {
+    expect(deserializeSave("")).toMatchObject({
+      ok: false,
+      error: { kind: "invalid_json" }
+    });
+    expect(deserializeSave("undefined")).toMatchObject({
+      ok: false,
+      error: { kind: "invalid_json" }
+    });
+    expect(deserializeSave("null")).toMatchObject({
+      ok: false,
+      error: { kind: "invalid_shape" }
+    });
+  });
+});


### PR DESCRIPTION
## Add save serialization v1 fixture and regression test

**Category:** `test` | **Contributor:** Go4187RVSvaW6yIXyIP0d

Closes #306

### Changes
Lock in the v1 save serialization format with a deterministic fixture, mirroring the existing tests/sim/fixtures/terrain-seed-42.json pattern (see tests/sim/terrainRegression.test.ts).

Create tests/sim/saveRegression.test.ts that:
1. Builds a canonical SaveState by reading the current src/sim/save.ts module (use the SaveState/SAVE_VERSION exports). Construct the SaveState in-place rather than running the full simulation step loop, so it stays deterministic and self-contained: pick seed=42, apply a fixed list of 3-5 mutations covering DIRT, AIR, and TORCH (or another non-default block), set a fixed player position with non-zero yaw and pitch, populate an inventory with 2-3 stacked entries and at least one empty slot, and choose a non-zero selected hotbar slot. The exact fields must match what serializeSave/deserializeSave actually accept today — read src/sim/save.ts to confirm the schema before writing the fixture.
2. Loads tests/sim/fixtures/save-v1.json from disk (use node:fs the same way tests/sim/terrainRegression.test.ts does, with the dynamic-import-via-string-literal workaround).
3. Asserts that serializeSave(canonicalState) equals the fixture file contents byte-for-byte (after both are normalized — pick whichever of trim() / parse-then-re-stringify mirrors what serializeSave already produces; the fixture must be the exact output of serializeSave).
4. Asserts that deserializeSave(fixtureContents) returns { ok: true, state } and that serializeSave(state) again equals the fixture contents byte-for-byte (round-trip).
5. Supports an UPDATE_SAVE_V1_FIXTURE=1 env var that rewrites the fixture file from serializeSave(canonicalState) and skips the equality assertions for that run — same shape as terrainRegression.test.ts uses UPDATE_TERRAIN_SEED_42_FIXTURE.
6. Includes a comment block at the top explaining how to regenerate the fixture and warning that any change is a save-format break for existing players.

Also write the initial tests/sim/fixtures/save-v1.json by running the test once with UPDATE_SAVE_V1_FIXTURE=1 (or by computing serializeSave on the canonical state and writing the result), then commit the resulting file. After generation, the test must pass without the env var set.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*