### PR TITLE
test: Add unit tests for src/app/hud.ts assembly

### DIFF
--- a/tests/app/hud.test.ts
+++ b/tests/app/hud.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createHud, toggleCraftingPanel, updateHud } from "../../src/app/hud";
+import { BlockId } from "../../src/sim/blocks";
+import { createHotbar, selectSlot, type Hotbar } from "../../src/sim/hotbar";
+import { createInventory, type Inventory } from "../../src/sim/inventory";
+import { createSimulation, type Simulation } from "../../src/sim/simulation";
+
+function makeSimulation(slots: Inventory["slots"]): Simulation {
+  const simulation = createSimulation({ seed: 1337 });
+
+  simulation.inventory = {
+    slots,
+    selectedHotbarSlot: 0
+  };
+
+  return simulation;
+}
+
+function makeHud(slots: Inventory["slots"], hotbar: Hotbar = createHotbar(9)) {
+  const simulation = makeSimulation(slots);
+
+  return {
+    hotbar,
+    hud: createHud(simulation, hotbar),
+    simulation
+  };
+}
+
+function getByTestId(root: ParentNode, testId: string): HTMLElement {
+  const element = root.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+
+  if (element === null) {
+    throw new Error(`Missing element with data-testid="${testId}".`);
+  }
+
+  return element;
+}
+
+function getHotbarSlot(root: ParentNode, index: number): HTMLElement {
+  return getByTestId(root, `hud-hotbar-slot-${index}`);
+}
+
+describe("app HUD", () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("assembles the root HUD with stable child selectors", () => {
+    const { hud } = makeHud([
+      { id: BlockId.DIRT, count: 8 },
+      null,
+      { id: BlockId.WOOD, count: 2 }
+    ]);
+
+    document.body.append(hud.root);
+
+    expect(hud.root.dataset.testid).toBe("hud-root");
+    expect(Array.from(hud.root.children)).toEqual(
+      expect.arrayContaining([
+        hud.hotbarElement,
+        hud.coordinatesLabel.element,
+        hud.inventoryPanel.element,
+        hud.craftingPanel.element,
+        hud.saveStatus.element,
+        hud.worldStatus
+      ])
+    );
+    expect(getByTestId(document, "hud-root")).toBe(hud.root);
+    expect(getByTestId(hud.root, "hud-hotbar")).toBe(hud.hotbarElement);
+    expect(getByTestId(hud.root, "hud-coordinates")).toBe(hud.coordinatesLabel.element);
+    expect(getByTestId(hud.root, "hud-inventory")).toBe(hud.inventoryPanel.element);
+    expect(getByTestId(hud.root, "hud-save-status")).toBe(hud.saveStatus.element);
+    expect(getByTestId(hud.root, "hud-crafting-panel")).toBe(hud.craftingPanel.element);
+  });
+
+  it("updates coordinate text and selected hotbar slot markers", () => {
+    const fixture = makeHud([
+      { id: BlockId.DIRT, count: 8 },
+      null,
+      { id: BlockId.WOOD, count: 2 }
+    ]);
+
+    expect(getHotbarSlot(fixture.hud.root, 0).dataset.selected).toBe("true");
+
+    fixture.simulation.player.position = [12.4, 65.5, -3.6];
+    fixture.hotbar = selectSlot(fixture.hotbar, 4);
+
+    updateHud(fixture.hud, fixture.simulation, fixture.hotbar);
+
+    expect(fixture.hud.coordinatesLabel.element.textContent).toBe("X: 12 Y: 66 Z: -4");
+    expect(getHotbarSlot(fixture.hud.root, 0).dataset.selected).toBeUndefined();
+    expect(getHotbarSlot(fixture.hud.root, 4).dataset.selected).toBe("true");
+  });
+
+  it("toggles the crafting panel visibility and returns to the original state", () => {
+    const { hud } = makeHud([{ id: BlockId.WOOD, count: 1 }]);
+    const craftingPanel = getByTestId(hud.root, "hud-crafting-panel");
+    const initialDisplay = craftingPanel.style.display;
+
+    expect(initialDisplay).toBe("none");
+
+    toggleCraftingPanel(hud);
+
+    expect(craftingPanel.style.display).toBe("block");
+
+    toggleCraftingPanel(hud);
+
+    expect(craftingPanel.style.display).toBe(initialDisplay);
+  });
+
+  it("keeps HUD widgets mounted for an empty inventory", () => {
+    const emptyInventory = createInventory(0);
+    const { hud } = makeHud(emptyInventory.slots);
+    const hotbar = getByTestId(hud.root, "hud-hotbar");
+    const inventory = getByTestId(hud.root, "hud-inventory");
+    const craftingPanel = getByTestId(hud.root, "hud-crafting-panel");
+    const recipeRows = Array.from(craftingPanel.querySelectorAll<HTMLElement>("[data-recipe-id]"));
+
+    expect(hotbar.children).toHaveLength(9);
+    expect(Array.from(hotbar.children, (slot) => (slot as HTMLElement).dataset.itemId)).toEqual(
+      Array.from({ length: 9 }, () => undefined)
+    );
+    expect(inventory.querySelectorAll("[data-item-id]")).toHaveLength(0);
+    expect(recipeRows.map((row) => row.dataset.craftable)).toEqual(["false", "false", "false"]);
+  });
+});


### PR DESCRIPTION
## Add unit tests for src/app/hud.ts assembly

**Category:** `test` | **Contributor:** imJ0swgQO8unfwOZepBFm

Closes #304

### Changes
Create tests/app/hud.test.ts that exercises the public API exported from src/app/hud.ts (createHud, updateHud, toggleCraftingPanel — match the actual exported names/signatures). Use the vitest JSDOM environment that other tests in tests/hud/*.test.ts already rely on (clear document.body in beforeEach). Build a minimal Simulation/Hotbar/Inventory fixture (use createSimulation or hand-rolled state matching the real types) and assert: (1) createHud returns/mounts a root element whose children include the hotbar, inventory, coordinates, saveStatus, and craftingPanel sub-elements, each discoverable via their existing stable [data-testid] selectors (hud-hotbar, hud-coordinates, hud-save-status, crafting-panel, plus whatever testid the inventory panel uses — read src/hud/inventoryPanel.ts to confirm); (2) updateHud applied with new player coordinates updates the coordinates label text, and changing the selected hotbar slot updates the [data-selected] marker on the hotbar slot; (3) toggleCraftingPanel flips a stable aria or data attribute on the crafting panel root (e.g. aria-hidden / data-open) so Playwright can key off it, and calling it twice returns to the original state. If any of those functions don't exist with those exact names, read src/app/hud.ts and adapt the tests to the real exports rather than inventing new ones — this is a TEST-ONLY task and must not modify src/app/hud.ts.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*