### PR TITLE
test: align save failure-mode coverage with storage contracts

### DIFF
--- a/tests/app/persistence.test.ts
+++ b/tests/app/persistence.test.ts
@@ -82,6 +82,22 @@ function makeSaveState(overrides: Partial<SaveState> = {}): SaveState {
 }
 
 describe("app persistence", () => {
+  it("treats unavailable localStorage as no saved game", () => {
+    const simulation = createSimulation({ seed: 1337 });
+
+    expect(restoreSavedGame(simulation, null)).toBe(false);
+  });
+
+  it("reports an error status when saving without localStorage", () => {
+    const simulation = createSimulation({ seed: 1337 });
+    const status = createSaveStatus();
+
+    expect(() => saveGame(simulation, null, status)).not.toThrow();
+    expect(status.states).toEqual([
+      { state: "error", detail: "localStorage unavailable" }
+    ]);
+  });
+
   it("restores saved world mutations into generated terrain", () => {
     const storage = new MemoryStorage();
     const saved = makeSaveState();

--- a/tests/sim/save.test.ts
+++ b/tests/sim/save.test.ts
@@ -52,7 +52,11 @@ describe("save codec", () => {
     expect(result.ok).toBe(false);
     expect(result).toMatchObject({
       ok: false,
-      error: { kind: "version_mismatch" }
+      error: {
+        kind: "version_mismatch",
+        expected: SAVE_VERSION,
+        actual: SAVE_VERSION + 1
+      }
     });
   });
 
@@ -87,6 +91,38 @@ describe("save codec", () => {
       ok: false,
       error: { kind: "invalid_shape" }
     });
+  });
+
+  it("returns invalid_shape for invalid nested payloads", () => {
+    const cases: unknown[] = [
+      { ...baseState, mutations: "not-an-array" },
+      {
+        ...baseState,
+        player: {
+          ...baseState.player,
+          position: [1, 2]
+        }
+      },
+      {
+        ...baseState,
+        inventory: {
+          slots: [{ block: BlockId.DIRT, count: "many" }]
+        }
+      },
+      {
+        ...baseState,
+        hotbar: {
+          selected: "first"
+        }
+      }
+    ];
+
+    for (const payload of cases) {
+      expect(deserializeSave(JSON.stringify(payload))).toMatchObject({
+        ok: false,
+        error: { kind: "invalid_shape" }
+      });
+    }
   });
 
   it("keeps sparse mutation payloads sparse", () => {

--- a/tests/sim/saveStorage.test.ts
+++ b/tests/sim/saveStorage.test.ts
@@ -81,13 +81,19 @@ describe("save storage", () => {
     expect(loadFromStorage("missing", storage)).toEqual({ ok: false, error: "missing" });
   });
 
-  it("returns malformed for invalid JSON or invalid save shape", () => {
+  it("returns malformed for invalid JSON", () => {
     const storage = new MemoryStorage();
 
     storage.setItem("bad-json", "{not json");
-    storage.setItem("bad-shape", JSON.stringify({ version: SAVE_VERSION }));
 
     expect(loadFromStorage("bad-json", storage)).toEqual({ ok: false, error: "malformed" });
+  });
+
+  it("returns malformed for invalid save shape", () => {
+    const storage = new MemoryStorage();
+
+    storage.setItem("bad-shape", JSON.stringify({ version: SAVE_VERSION }));
+
     expect(loadFromStorage("bad-shape", storage)).toEqual({ ok: false, error: "malformed" });
   });
 
@@ -95,6 +101,17 @@ describe("save storage", () => {
     const storage = new MemoryStorage();
 
     storage.setError = { name: "QuotaExceededError" };
+
+    expect(saveToStorage("save", baseState, storage)).toEqual({
+      ok: false,
+      error: "quota_exceeded"
+    });
+  });
+
+  it("recognizes DOMException quota failures", () => {
+    const storage = new MemoryStorage();
+
+    storage.setError = new DOMException("Quota exceeded", "QuotaExceededError");
 
     expect(saveToStorage("save", baseState, storage)).toEqual({
       ok: false,


### PR DESCRIPTION
## Summary

Fixes #275.

Adds save failure-mode tests that match the current contracts:
- codec invalid_json / invalid_shape / version_mismatch failure shapes
- storage malformed JSON/schema mismatch and quota-exceeded handling
- app-level missing localStorage behavior through restoreSavedGame/saveGame with null storage

## Validation

- pnpm test -- tests/sim/saveStorage.test.ts tests/sim/save.test.ts tests/app/persistence.test.ts
- pnpm tsc --noEmit
- pnpm eslint tests/sim/saveStorage.test.ts tests/sim/save.test.ts tests/app/persistence.test.ts --max-warnings 0
