### PR TITLE
test: Add unit tests for createApp persistence-vs-seeding branch

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -38,6 +38,7 @@ export type RendererFactory = (canvas?: HTMLCanvasElement) => AppRenderer;
 export interface CreateAppOptions {
   readonly canvas?: HTMLCanvasElement;
   readonly rendererFactory?: RendererFactory;
+  readonly getLocalStorage?: () => Storage | null;
 }
 
 const CAMERA_EYE_HEIGHT = 1.62;
@@ -54,7 +55,7 @@ export function createApp(options: CreateAppOptions = {}): App {
   const camera = createPlayerCamera();
   const renderer = (options.rendererFactory ?? createRenderer)(options.canvas);
   const simulation = createSimulation({ seed: 1337 });
-  const storage = getLocalStorage();
+  const storage = (options.getLocalStorage ?? getLocalStorage)();
   const loaded = restoreSavedGame(simulation, storage);
   const worldRenderer = createWorldRenderer(scene, simulation.world);
   const hotbar = createHotbar(9);
@@ -158,7 +159,7 @@ function selectedHotbar(hotbar: Hotbar, simulation: Simulation): Hotbar {
   };
 }
 
-function seedStarterInventory(simulation: Simulation): void {
+export function seedStarterInventory(simulation: Simulation): void {
   simulation.inventory = addItem(simulation.inventory, BlockId.WOOD, 2).inventory;
   simulation.inventory = addItem(simulation.inventory, BlockId.DIRT, 6).inventory;
   simulation.inventory = selectHotbarSlot(simulation.inventory, 0);

--- a/tests/app/createApp.test.ts
+++ b/tests/app/createApp.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createApp, type App, type AppRenderer } from "../../src/app";
+import { BlockId } from "../../src/sim/blocks";
+import type { Inventory } from "../../src/sim/inventory";
+import { SAVE_VERSION, serializeSave, type SaveState } from "../../src/sim/save";
+
+const SAVE_KEY = "blockstead:mvp-save";
+
+class MemoryStorage implements Storage {
+  [name: string]: unknown;
+
+  private readonly values = new Map<string, string>();
+
+  public get length(): number {
+    return this.values.size;
+  }
+
+  public clear(): void {
+    this.values.clear();
+  }
+
+  public getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  public key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  public removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  public setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+const apps: App[] = [];
+
+function createTestRenderer(): AppRenderer {
+  return {
+    domElement: document.createElement("canvas"),
+    render() {},
+    setSize() {}
+  };
+}
+
+function createTrackedApp(storage: Storage | null): App {
+  const app = createApp({
+    rendererFactory: createTestRenderer,
+    getLocalStorage: () => storage
+  });
+
+  apps.push(app);
+
+  return app;
+}
+
+function getByTestId(root: ParentNode, testId: string): HTMLElement {
+  const element = root.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+
+  if (element === null) {
+    throw new Error(`Missing element with test id "${testId}".`);
+  }
+
+  return element;
+}
+
+function countItem(inventory: Inventory, block: BlockId): number {
+  return inventory.slots.reduce(
+    (total, slot) => (slot?.id === block ? total + slot.count : total),
+    0
+  );
+}
+
+function createSavedState(): SaveState {
+  const slots: SaveState["inventory"]["slots"] = Array.from(
+    { length: 36 },
+    (): SaveState["inventory"]["slots"][number] => null
+  );
+
+  slots[0] = { block: BlockId.STONE, count: 3 };
+  slots[5] = { block: BlockId.WOOD, count: 1 };
+
+  return {
+    version: SAVE_VERSION,
+    seed: 1337,
+    mutations: [],
+    player: {
+      position: [9.25, 10.5, -3.75],
+      orientation: {
+        yaw: 0.5,
+        pitch: -0.25
+      }
+    },
+    inventory: {
+      slots
+    },
+    hotbar: {
+      selected: 5
+    }
+  };
+}
+
+describe("createApp persistence branch", () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  afterEach(() => {
+    for (const app of apps.splice(0)) {
+      app.dispose();
+    }
+  });
+
+  it("loads a valid save without applying the starter inventory seed", () => {
+    const storage = new MemoryStorage();
+    const saved = createSavedState();
+
+    storage.setItem(SAVE_KEY, serializeSave(saved));
+
+    const app = createTrackedApp(storage);
+    const saveStatus = getByTestId(app.element, "hud-save-status");
+
+    expect(saveStatus.dataset.state).toBe("loaded");
+    expect(app.simulation.player.position).toEqual(saved.player.position);
+    expect(app.simulation.selectedHotbarSlot).toBe(saved.hotbar.selected);
+    expect(app.simulation.inventory.selectedHotbarSlot).toBe(saved.hotbar.selected);
+    expect(app.simulation.inventory.slots).toEqual([
+      { id: BlockId.STONE, count: 3 },
+      null,
+      null,
+      null,
+      null,
+      { id: BlockId.WOOD, count: 1 },
+      ...Array.from({ length: 30 }, () => null)
+    ]);
+    expect(countItem(app.simulation.inventory, BlockId.WOOD)).toBe(1);
+    expect(countItem(app.simulation.inventory, BlockId.DIRT)).toBe(0);
+  });
+
+  it("seeds a fresh startup with the starter inventory", () => {
+    const app = createTrackedApp(new MemoryStorage());
+
+    expect(countItem(app.simulation.inventory, BlockId.WOOD)).toBe(2);
+    expect(countItem(app.simulation.inventory, BlockId.DIRT)).toBe(6);
+    expect(
+      app.simulation.inventory.slots.filter((slot) => slot !== null)
+    ).toEqual([
+      { id: BlockId.WOOD, count: 2 },
+      { id: BlockId.DIRT, count: 6 }
+    ]);
+    expect(app.simulation.inventory.selectedHotbarSlot).toBe(0);
+    expect(app.simulation.selectedHotbarSlot).toBe(0);
+  });
+});


### PR DESCRIPTION
## Add unit tests for createApp persistence-vs-seeding branch

**Category:** `test` | **Contributor:** rc5aXQArXebGxCxzFJJ24

Closes #340

### Changes
Add `tests/app/createApp.test.ts` exercising the two startup paths in `createApp` from `src/app.ts` without Playwright. Use a fake renderer (no real Three.js/WebGL) injected via the existing rendererFactory hook, and an injected in-memory Storage stub via the existing getLocalStorage seam. If `createApp` does not already accept these as injectable dependencies, make the smallest possible change to `src/app.ts` to allow injection (e.g. add optional `rendererFactory` and `getLocalStorage` params with the current behavior as defaults) — keep the existing main.ts call site working unchanged. Likewise, if the starter-inventory seeding logic is not already a pure callable helper, export `seedStarterInventory` (or equivalent) from `src/app.ts` as a pure function that returns/mutates a Simulation's inventory deterministically. Tests must assert: (a) Loaded path — pre-populate the injected storage with a valid serialized SaveState (use `serializeSave` and `SAVE_VERSION` from `src/sim/save.ts`, mirroring the approach in `tests/app/persistence.test.ts`) representing a known inventory and player position; after `createApp` runs, the returned hud.saveStatus element has `data-state="loaded"`, the simulation reflects the saved inventory and selectedHotbarSlot (NOT the starter 2 WOOD + 6 DIRT seed), and starter seeding was not applied. (b) Fresh path — with empty storage, after `createApp` runs the simulation.inventory contains exactly 2 WOOD and 6 DIRT (verify via slot counts using BlockId.WOOD and BlockId.DIRT) and inventory.selectedHotbarSlot === 0. Use a JSDOM-friendly setup (vitest's default jsdom env) and replace document.body children in beforeEach. Do NOT call any real renderer; the fake rendererFactory should return a stub matching only the surface `createApp` actually consumes. Keep changes to `src/app.ts` minimal and additive — do not reshape unrelated wiring.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*