### PR TITLE
bug_fix: Invoke distributeCoalOre from generateChunk so seeded worlds contain coal

### DIFF
--- a/src/sim/terrain.ts
+++ b/src/sim/terrain.ts
@@ -1,5 +1,6 @@
 import { BlockId } from "./blocks";
 import { CHUNK_SIZE, createChunk, setBlock, type Chunk } from "./chunk";
+import { distributeCoalOre } from "./oreDistribution";
 import { createRng, hashStringToSeed } from "./random";
 
 const DIRT_DEPTH = 3;
@@ -35,6 +36,8 @@ export function generateChunk(
       }
     }
   }
+
+  distributeCoalOre(chunk, seed, chunkCoord);
 
   return chunk;
 }

--- a/tests/sim/terrain.test.ts
+++ b/tests/sim/terrain.test.ts
@@ -5,6 +5,7 @@ import { CHUNK_SIZE, getBlock, type Chunk } from "../../src/sim/chunk";
 import { generateChunk } from "../../src/sim/terrain";
 
 const DIRT_DEPTH = 3;
+const STONE_LAYER_BLOCKS = [BlockId.STONE, BlockId.COAL_ORE] as const;
 
 describe("terrain generator", () => {
   it("creates byte-equal chunks for the same seed and coordinate", () => {
@@ -33,7 +34,7 @@ describe("terrain generator", () => {
         }
 
         for (let y = 0; y < topY - DIRT_DEPTH; y += 1) {
-          expect(getBlock(chunk, x, y, z)).toBe(BlockId.STONE);
+          expect(STONE_LAYER_BLOCKS).toContain(getBlock(chunk, x, y, z));
         }
       }
     }

--- a/tests/sim/terrainRegression.test.ts
+++ b/tests/sim/terrainRegression.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, it } from "vitest";
 
 import { BlockId } from "../../src/sim/blocks";
 import { CHUNK_SIZE, chunkIndex, type Chunk } from "../../src/sim/chunk";
-import { distributeCoalOre } from "../../src/sim/oreDistribution";
 import { generateChunk } from "../../src/sim/terrain";
 
 // If this test fails after intentional terrain changes, regenerate the fixture by running
@@ -94,11 +93,7 @@ function createFixture(): TerrainFixture {
 }
 
 function generateTerrainPipeline(seed: number, coord: ChunkCoord): Chunk {
-  const chunk = generateChunk(seed, coord);
-
-  distributeCoalOre(chunk, seed, coord);
-
-  return chunk;
+  return generateChunk(seed, coord);
 }
 
 function loadFixture(): TerrainFixture {


### PR DESCRIPTION
## Invoke distributeCoalOre from generateChunk so seeded worlds contain coal

**Category:** `bug_fix` | **Contributor:** rc5aXQArXebGxCxzFJJ24

Closes #344

### Changes
Wire the existing distributeCoalOre helper into the terrain pipeline so seeded chunk generation produces deterministic coal veins inside the stone layer, making the torch recipe (stick + coal) reachable from a seeded world. Inspect src/sim/oreDistribution.ts to confirm its signature (distributeCoalOre(chunk, seed, chunkCoord)). Modify src/sim/terrain.ts so generateChunk calls distributeCoalOre after laying down stone/dirt/grass/air, passing the same seed and chunkCoord that generateChunk received. The call must come AFTER the stone fill so coal ore can replace stone blocks. Then update tests/sim/terrain.test.ts: the existing stone-column assertion `expect(getBlock(chunk, x, y, z)).toBe(BlockId.STONE)` will start failing because some stone blocks are now COAL_ORE — change that assertion to accept either BlockId.STONE or BlockId.COAL_ORE (e.g. via toMatch / oneOf / explicit OR check) so the column-ordering invariant still passes. Do not alter the air/grass/dirt assertions. Update tests/sim/terrainRegression.test.ts only as needed to reflect that generateChunk now owns ore distribution; remove any duplicate manual distributeCoalOre call in the regression helper instead of adding production idempotence guards. Verify tests/sim/terrainRegression.test.ts passes against the existing tests/sim/fixtures/terrain-seed-42.json fixture, which already encodes coal ore (block id 9) at specific positions for seed=42 — your wiring must reproduce those exact positions. Do not regenerate or modify the fixture file. If the regression test fails because positions differ, the integration order or seed/coord mixing is wrong; fix the wiring rather than the fixture.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*