### PR TITLE
bug_fix: Resolve crafted output names via item-or-block lookup in onCraft

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,10 +11,11 @@ import { getLocalStorage, restoreSavedGame, saveGame } from "./app/persistence";
 import { applyPlayerPose, createPlayerCamera } from "./render/camera";
 import { createScene } from "./render/scene";
 import { createWorldRenderer, type WorldRenderer } from "./render/worldRenderer";
-import { BlockId, getBlockDefinition } from "./sim/blocks";
+import { BlockId } from "./sim/blocks";
 import { resolveCraft } from "./sim/craftAction";
 import { createHotbar, type Hotbar } from "./sim/hotbar";
 import { addItem, selectHotbarSlot } from "./sim/inventory";
+import { getItemOrBlockName } from "./sim/items";
 import { createSimulation, type Simulation } from "./sim/simulation";
 
 export interface AppRenderer {
@@ -82,7 +83,7 @@ export function createApp(options: CreateAppOptions = {}): App {
 
     if (result.ok) {
       simulation.inventory = selectHotbarSlot(result.inventory, simulation.selectedHotbarSlot);
-      hud.worldStatus.textContent = `Crafted ${getBlockDefinition(result.output.item).name}`;
+      hud.worldStatus.textContent = `Crafted ${getItemOrBlockName(result.output.item)}`;
     } else {
       hud.worldStatus.textContent = "Missing recipe inputs";
     }

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -1,4 +1,4 @@
-import { BlockId } from "./blocks";
+import { BLOCK_REGISTRY, BlockId, getBlockDefinition } from "./blocks";
 
 export const ItemId = {
   WOOD_LOG: 100,
@@ -48,6 +48,10 @@ export const ITEM_REGISTRY = {
   }
 } as const satisfies Readonly<Record<ItemId, ItemDef>>;
 
+function hasOwn<T extends object>(object: T, key: PropertyKey): key is keyof T {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
 export function getItemDefinition(id: ItemId): ItemDef {
   const definition = ITEM_REGISTRY[id];
 
@@ -56,4 +60,16 @@ export function getItemDefinition(id: ItemId): ItemDef {
   }
 
   return definition;
+}
+
+export function getItemOrBlockName(id: number): string {
+  if (hasOwn(ITEM_REGISTRY, id)) {
+    return ITEM_REGISTRY[id].name;
+  }
+
+  if (hasOwn(BLOCK_REGISTRY, id)) {
+    return getBlockDefinition(id).name;
+  }
+
+  throw new Error(`Unknown item or block id: ${id}`);
 }

--- a/tests/app/createApp.test.ts
+++ b/tests/app/createApp.test.ts
@@ -155,4 +155,21 @@ describe("createApp persistence branch", () => {
     expect(app.simulation.inventory.selectedHotbarSlot).toBe(0);
     expect(app.simulation.selectedHotbarSlot).toBe(0);
   });
+
+  it("shows the crafted output name when crafting sticks", () => {
+    const storage = new MemoryStorage();
+    const saved = createSavedState();
+
+    saved.inventory.slots.fill(null);
+    saved.inventory.slots[0] = { block: BlockId.PLANKS, count: 2 };
+    storage.setItem(SAVE_KEY, serializeSave(saved));
+
+    const app = createTrackedApp(storage);
+    const sticksRecipe = getByTestId(app.element, "craft-recipe-sticks");
+    const worldStatus = getByTestId(app.element, "hud-world-status");
+
+    sticksRecipe.click();
+
+    expect(worldStatus.textContent).toBe("Crafted Stick");
+  });
 });


### PR DESCRIPTION
## Resolve crafted output names via item-or-block lookup in onCraft

**Category:** `bug_fix` | **Contributor:** rc5aXQArXebGxCxzFJJ24

Closes #364

### Changes
src/app.ts currently resolves the crafted output's display name with `getBlockDefinition(result.output.item).name` inside its onCraft handler. Recipes include outputs (sticks, torches) that are conceptually items rather than placeable blocks, and the crafting/items module must stay separable from blocks per the constitution. Add a small shared resolver that returns a human-readable name for either a block id or an item id and use it in onCraft. Concretely: 1) In src/sim/items.ts, export a helper such as `getItemOrBlockName(id: number): string` (or a similarly named function — whichever fits the file's existing style) that first looks up ITEM_REGISTRY and falls back to BLOCK_REGISTRY via getBlockDefinition; if neither matches, throw an explanatory error consistent with the existing `getItemDefinition` throw style. 2) Update src/app.ts onCraft so the success feedback message uses this resolver instead of `getBlockDefinition(result.output.item).name`. Keep the change scoped to the onCraft handler — do not refactor unrelated areas. 3) Extend tests/app/createApp.test.ts with a test that drives a successful sticks craft (seeding inventory with the required PLANKS through the same path other createApp tests use) and asserts the action feedback / HUD message contains 'Crafted Stick' (or equivalent — match whatever string format the existing onCraft success message uses, e.g. `Crafted Stick x4`). The assertion must fail today (when the lookup goes through getBlockDefinition only — verify by reading the current onCraft message format) and pass after the fix. Do NOT change recipe shapes, BlockId/ItemId numeric values, or other modules.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*