### PR TITLE
bug_fix: resolve crafted item output names

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,10 +11,11 @@ import { getLocalStorage, restoreSavedGame, saveGame } from "./app/persistence";
 import { applyPlayerPose, createPlayerCamera } from "./render/camera";
 import { createScene } from "./render/scene";
 import { createWorldRenderer, type WorldRenderer } from "./render/worldRenderer";
-import { BlockId, getBlockDefinition } from "./sim/blocks";
+import { BlockId } from "./sim/blocks";
 import { resolveCraft } from "./sim/craftAction";
 import { createHotbar, type Hotbar } from "./sim/hotbar";
 import { addItem, selectHotbarSlot } from "./sim/inventory";
+import { getItemOrBlockName } from "./sim/items";
 import { createSimulation, type Simulation } from "./sim/simulation";
 
 export interface AppRenderer {
@@ -82,7 +83,7 @@ export function createApp(options: CreateAppOptions = {}): App {
 
     if (result.ok) {
       simulation.inventory = selectHotbarSlot(result.inventory, simulation.selectedHotbarSlot);
-      hud.worldStatus.textContent = `Crafted ${getBlockDefinition(result.output.item).name}`;
+      hud.worldStatus.textContent = `Crafted ${getItemOrBlockName(result.output.item)}`;
     } else {
       hud.worldStatus.textContent = "Missing recipe inputs";
     }

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -1,4 +1,4 @@
-import { BlockId } from "./blocks";
+import { BLOCK_REGISTRY, BlockId, getBlockDefinition } from "./blocks";
 
 export const ItemId = {
   WOOD_LOG: 100,
@@ -48,6 +48,10 @@ export const ITEM_REGISTRY = {
   }
 } as const satisfies Readonly<Record<ItemId, ItemDef>>;
 
+function hasOwn<T extends object>(object: T, key: PropertyKey): key is keyof T {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
 export function getItemDefinition(id: ItemId): ItemDef {
   const definition = ITEM_REGISTRY[id];
 
@@ -56,4 +60,16 @@ export function getItemDefinition(id: ItemId): ItemDef {
   }
 
   return definition;
+}
+
+export function getItemOrBlockName(id: number): string {
+  if (hasOwn(ITEM_REGISTRY, id)) {
+    return ITEM_REGISTRY[id].name;
+  }
+
+  if (hasOwn(BLOCK_REGISTRY, id)) {
+    return getBlockDefinition(id).name;
+  }
+
+  throw new Error(`Unknown item or block id: ${id}`);
 }

--- a/tests/app/createApp.test.ts
+++ b/tests/app/createApp.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createApp, type App, type AppRenderer } from "../../src/app";
 import { BlockId } from "../../src/sim/blocks";
-import type { Inventory } from "../../src/sim/inventory";
+import { addItem, type Inventory } from "../../src/sim/inventory";
+import { ItemId } from "../../src/sim/items";
 import { SAVE_VERSION, serializeSave, type SaveState } from "../../src/sim/save";
 
 const SAVE_KEY = "blockstead:mvp-save";
@@ -113,6 +114,9 @@ describe("createApp persistence branch", () => {
     for (const app of apps.splice(0)) {
       app.dispose();
     }
+
+    vi.doUnmock("../../src/sim/craftAction");
+    vi.resetModules();
   });
 
   it("loads a valid save without applying the starter inventory seed", () => {
@@ -154,5 +158,38 @@ describe("createApp persistence branch", () => {
     ]);
     expect(app.simulation.inventory.selectedHotbarSlot).toBe(0);
     expect(app.simulation.selectedHotbarSlot).toBe(0);
+  });
+
+  it("shows crafted block-backed names in the HUD after crafting", () => {
+    const app = createTrackedApp(new MemoryStorage());
+
+    app.simulation.inventory = addItem(app.simulation.inventory, BlockId.PLANKS, 2).inventory;
+    getByTestId(app.element, "craft-recipe-sticks").click();
+
+    expect(getByTestId(app.element, "hud-world-status").textContent).toBe("Crafted Stick");
+    expect(countItem(app.simulation.inventory, BlockId.STICK)).toBe(4);
+  });
+
+  it("shows crafted item-only names in the HUD after crafting", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/sim/craftAction", () => ({
+      resolveCraft: vi.fn((inventory: Inventory) => ({
+        ok: true,
+        inventory,
+        output: { item: ItemId.STICK, count: 1 }
+      }))
+    }));
+
+    const { createApp: createMockedApp } = await import("../../src/app");
+    const app = createMockedApp({
+      rendererFactory: createTestRenderer,
+      getLocalStorage: () => new MemoryStorage()
+    });
+
+    apps.push(app);
+
+    getByTestId(app.element, "craft-recipe-sticks").click();
+
+    expect(getByTestId(app.element, "hud-world-status").textContent).toBe("Crafted Stick");
   });
 });


### PR DESCRIPTION
## Summary
- add a shared item-or-block display name resolver
- use it from createApp crafting feedback
- add regression coverage where the onCraft path receives an ItemId output via a scoped craftAction mock

Closes #364

## Validation
- pnpm tsc --noEmit
- pnpm vitest run tests/app/createApp.test.ts tests/sim/items.test.ts
- pnpm eslint src/app.ts src/sim/items.ts tests/app/createApp.test.ts --max-warnings 0
- pnpm test
