### PR TITLE
bug_fix: Wire src/hud/index.ts barrel re-exports and replace todo test

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -2,9 +2,8 @@
 // attributes rather than canvas-only rendering so Playwright can assert the
 // selected block, inventory counts, active recipe, save status, and player coordinates.
 
-// export * from './hotbar';
-// export * from './inventoryPanel';
-// export * from './coordinatesLabel';
-// export * from './saveStatus';
-
-export {};
+export * from "./hotbar";
+export * from "./inventoryPanel";
+export * from "./coordinatesLabel";
+export * from "./saveStatus";
+export * from "./craftingPanel";

--- a/tests/hud/index.test.ts
+++ b/tests/hud/index.test.ts
@@ -1,5 +1,21 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-describe('hud module', () => {
-  it.todo('exposes hotbar, inventory, coordinates, and save-status indicators');
+import {
+  createCoordinatesLabel,
+  createCraftingPanel,
+  createHotbarElement,
+  createInventoryPanel,
+  createSaveStatus,
+  updateHotbarElement
+} from "../../src/hud";
+
+describe("hud module", () => {
+  it("exposes HUD factories through the barrel", () => {
+    expect(createHotbarElement).toBeTypeOf("function");
+    expect(updateHotbarElement).toBeTypeOf("function");
+    expect(createInventoryPanel).toBeTypeOf("function");
+    expect(createCoordinatesLabel).toBeTypeOf("function");
+    expect(createSaveStatus).toBeTypeOf("function");
+    expect(createCraftingPanel).toBeTypeOf("function");
+  });
 });


### PR DESCRIPTION
## Wire src/hud/index.ts barrel re-exports and replace todo test

**Category:** `bug_fix` | **Contributor:** rc5aXQArXebGxCxzFJJ24

Closes #354

### Changes
Replace the placeholder `export {}` in src/hud/index.ts with real `export *` (or named) re-exports for ./hotbar, ./inventoryPanel, ./coordinatesLabel, ./saveStatus, and ./craftingPanel so HUD consumers and Playwright fixtures can import factories from a single barrel. Then rewrite tests/hud/index.test.ts to drop the it.todo and add a real vitest test that imports from `../../src/hud` (the barrel) and asserts the expected factory functions are exposed (createHotbarElement, updateHotbarElement, createInventoryPanel, createCoordinatesLabel, createSaveStatus, createCraftingPanel — verify against the actual exports of each module before listing). Keep the existing comment in src/hud/index.ts explaining the DOM-label rationale, or replace it with an equivalent short note; do not remove the rationale entirely.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*