### PR TITLE
bug_fix: Wire src/render/index.ts barrel re-exports and replace placeholder test

### DIFF
--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,8 +1,8 @@
 // Presentation-only Three.js rendering helpers live in this directory.
 // Scene, camera, and chunk mesh helpers must not own deterministic simulation state.
 
-// export * from './scene';
-// export * from './camera';
-// export * from './chunkMesh';
-
-export {};
+export * from "./scene";
+export * from "./camera";
+export * from "./chunkMesh";
+export * from "./worldRenderer";
+export * from "./blockTarget";

--- a/tests/render/index.test.ts
+++ b/tests/render/index.test.ts
@@ -1,5 +1,25 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-describe('render module', () => {
-  it.todo('exposes Three.js scene, camera, and mesh helpers');
+import {
+  applyPlayerPose,
+  buildChunkMesh,
+  createBlockTargetMesh,
+  createPlayerCamera,
+  createScene,
+  createWorldRenderer,
+  getBlockFaceUV,
+  setBlockTarget
+} from "../../src/render";
+
+describe("render module", () => {
+  it("re-exports render helpers from the barrel", () => {
+    expect(createScene).toEqual(expect.any(Function));
+    expect(createPlayerCamera).toEqual(expect.any(Function));
+    expect(applyPlayerPose).toEqual(expect.any(Function));
+    expect(buildChunkMesh).toEqual(expect.any(Function));
+    expect(getBlockFaceUV).toEqual(expect.any(Function));
+    expect(createWorldRenderer).toEqual(expect.any(Function));
+    expect(createBlockTargetMesh).toEqual(expect.any(Function));
+    expect(setBlockTarget).toEqual(expect.any(Function));
+  });
 });


### PR DESCRIPTION
## Wire src/render/index.ts barrel re-exports and replace placeholder test

**Category:** `bug_fix` | **Contributor:** rc5aXQArXebGxCxzFJJ24

Closes #355

### Changes
Replace the empty `export {}` and commented-out lines in src/render/index.ts with real `export * from './scene'`, `./camera'`, `./chunkMesh'`, `./worldRenderer'`, and `./blockTarget'` (mirror the comment-free style of src/input/index.ts). Then rewrite tests/render/index.test.ts to import the public surface (e.g., createScene, createPlayerCamera, applyPlayerPose, buildChunkMesh, getBlockFaceUV, createWorldRenderer, createBlockTargetMesh, setBlockTarget) from '../../src/render' and assert each is a function — following the pattern in tests/input/index.test.ts. Remove the `it.todo` placeholder.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*