### PR TITLE
feature: Surface pointer lock state in input controller and HUD hint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -94,6 +94,7 @@ export function createApp(options: CreateAppOptions = {}): App {
   worldRenderer.sync();
   updateCamera(camera, simulation);
   updateHud(hud, simulation, selectedHotbar(hotbar, simulation));
+  updatePointerLockHint(hud, input);
 
   return {
     element,
@@ -139,6 +140,14 @@ function stepApp(
   worldRenderer.sync();
   updateCamera(camera, simulation);
   updateHud(hud, simulation, selectedHotbar(hotbar, simulation));
+  updatePointerLockHint(hud, input);
+}
+
+function updatePointerLockHint(hud: HudElements, input: InputController): void {
+  hud.pointerLockHint.update({
+    supported: input.isPointerLockSupported(),
+    locked: input.isPointerLocked()
+  });
 }
 
 function updateCamera(camera: THREE.PerspectiveCamera, simulation: Simulation): void {

--- a/src/app/hud.ts
+++ b/src/app/hud.ts
@@ -2,6 +2,7 @@ import { createCoordinatesLabel, type CoordinatesLabel } from "../hud/coordinate
 import { createCraftingPanel, type CraftingPanel } from "../hud/craftingPanel";
 import { createHotbarElement, updateHotbarElement } from "../hud/hotbar";
 import { createInventoryPanel, type InventoryPanel } from "../hud/inventoryPanel";
+import { createPointerLockHint, type PointerLockHint } from "../hud/pointerLockHint";
 import { createSaveStatus, type SaveStatusIndicator } from "../hud/saveStatus";
 import type { Hotbar } from "../sim/hotbar";
 import type { Simulation } from "../sim/simulation";
@@ -14,6 +15,7 @@ export interface HudElements {
   readonly craftingPanel: CraftingPanel;
   readonly saveStatus: SaveStatusIndicator;
   readonly worldStatus: HTMLElement;
+  readonly pointerLockHint: PointerLockHint;
 }
 
 export function createHud(simulation: Simulation, hotbar: Hotbar): HudElements {
@@ -23,6 +25,7 @@ export function createHud(simulation: Simulation, hotbar: Hotbar): HudElements {
   const craftingPanel = createCraftingPanel();
   const saveStatus = createSaveStatus();
   const worldStatus = document.createElement("div");
+  const pointerLockHint = createPointerLockHint();
   const hotbarElement = createHotbarElement({
     hotbar,
     inventory: simulation.inventory
@@ -72,6 +75,10 @@ export function createHud(simulation: Simulation, hotbar: Hotbar): HudElements {
   worldStatus.style.left = "16px";
   worldStatus.style.top = "80px";
 
+  pointerLockHint.element.style.position = "absolute";
+  pointerLockHint.element.style.left = "16px";
+  pointerLockHint.element.style.bottom = "24px";
+
   hotbarElement.style.position = "absolute";
   hotbarElement.style.left = "50%";
   hotbarElement.style.bottom = "24px";
@@ -86,6 +93,7 @@ export function createHud(simulation: Simulation, hotbar: Hotbar): HudElements {
     craftingPanel.element,
     saveStatus.element,
     worldStatus,
+    pointerLockHint.element,
     hotbarElement
   );
   updateHud(
@@ -96,7 +104,8 @@ export function createHud(simulation: Simulation, hotbar: Hotbar): HudElements {
       inventoryPanel,
       craftingPanel,
       saveStatus,
-      worldStatus
+      worldStatus,
+      pointerLockHint
     },
     simulation,
     hotbar
@@ -109,7 +118,8 @@ export function createHud(simulation: Simulation, hotbar: Hotbar): HudElements {
     inventoryPanel,
     craftingPanel,
     saveStatus,
-    worldStatus
+    worldStatus,
+    pointerLockHint
   };
 }
 

--- a/src/app/inputController.ts
+++ b/src/app/inputController.ts
@@ -1,15 +1,25 @@
 import {
+  lookIntent,
   mineIntent,
   moveIntent,
   placeIntent,
   selectHotbarIntent,
   type ActionIntent,
   type IntentAxis,
-  type IntentFrame
+  type IntentFrame,
+  type LookIntent
 } from "../input/intents";
+import {
+  createPointerLock,
+  type PointerLockAdapter,
+  type PointerLockDocument
+} from "../input/pointerLock";
 
 export interface InputController {
   readonly pressedKeys: ReadonlySet<string>;
+  isPointerLockSupported(): boolean;
+  isPointerLocked(): boolean;
+  drainLook(): LookIntent | null;
   drainActions(): ReadonlyArray<ActionIntent>;
   dispose(): void;
 }
@@ -19,13 +29,32 @@ export interface InputActions {
   onSave(): void;
 }
 
+export interface InputControllerOptions {
+  readonly pointerLock?: PointerLockAdapter | null;
+}
+
 export function createInputController(
   canvas: HTMLCanvasElement,
-  actions: InputActions
+  actions: InputActions,
+  options: InputControllerOptions = {}
 ): InputController {
   const pressedKeys = new Set<string>();
   const pendingActions: ActionIntent[] = [];
   const view = canvas.ownerDocument.defaultView;
+  const pointerLock =
+    options.pointerLock === undefined
+      ? createCanvasPointerLock(canvas)
+      : options.pointerLock;
+  let hasPendingLook = false;
+  let pendingLookX = 0;
+  let pendingLookY = 0;
+
+  const unsubscribePointerLock =
+    pointerLock?.on((event) => {
+      pendingLookX += event.movementX;
+      pendingLookY += event.movementY;
+      hasPendingLook = true;
+    }) ?? (() => undefined);
 
   function handleKeyDown(event: KeyboardEvent): void {
     pressedKeys.add(event.code);
@@ -86,6 +115,23 @@ export function createInputController(
 
   return {
     pressedKeys,
+    isPointerLockSupported() {
+      return pointerLock !== null;
+    },
+    isPointerLocked() {
+      return pointerLock?.isLocked() ?? false;
+    },
+    drainLook() {
+      if (!hasPendingLook) {
+        return null;
+      }
+
+      const look = lookIntent(pendingLookX, pendingLookY);
+      pendingLookX = 0;
+      pendingLookY = 0;
+      hasPendingLook = false;
+      return look;
+    },
     drainActions() {
       const drained = [...pendingActions];
       pendingActions.length = 0;
@@ -96,6 +142,8 @@ export function createInputController(
       canvas.removeEventListener("contextmenu", handleContextMenu);
       view?.removeEventListener("keydown", handleKeyDown);
       view?.removeEventListener("keyup", handleKeyUp);
+      unsubscribePointerLock();
+      pointerLock?.dispose();
     }
   };
 }
@@ -105,7 +153,7 @@ export function nextFrameIntents(input: InputController): IntentFrame {
 
   return {
     move,
-    look: null,
+    look: input.drainLook(),
     actions: input.drainActions()
   };
 }
@@ -145,4 +193,29 @@ function readHotbarSlot(event: KeyboardEvent): number | null {
   }
 
   return null;
+}
+
+function createCanvasPointerLock(canvas: HTMLCanvasElement): PointerLockAdapter | null {
+  if (
+    typeof canvas.requestPointerLock !== "function" ||
+    !isPointerLockDocument(canvas.ownerDocument)
+  ) {
+    return null;
+  }
+
+  return createPointerLock(canvas);
+}
+
+function isPointerLockDocument(value: unknown): value is PointerLockDocument {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  return (
+    "pointerLockElement" in value &&
+    "addEventListener" in value &&
+    typeof value.addEventListener === "function" &&
+    "removeEventListener" in value &&
+    typeof value.removeEventListener === "function"
+  );
 }

--- a/src/hud/pointerLockHint.ts
+++ b/src/hud/pointerLockHint.ts
@@ -1,0 +1,28 @@
+export interface PointerLockHintState {
+  readonly supported: boolean;
+  readonly locked: boolean;
+}
+
+export interface PointerLockHint {
+  element: HTMLElement;
+  update(state: PointerLockHintState): void;
+}
+
+export function createPointerLockHint(): PointerLockHint {
+  const element = document.createElement("div");
+  element.dataset.testid = "hud-pointer-lock-hint";
+
+  function update(state: PointerLockHintState): void {
+    const stateName = state.supported ? (state.locked ? "locked" : "unlocked") : "unsupported";
+
+    element.dataset.state = stateName;
+    element.textContent = stateName === "locked" ? "Pointer locked" : stateName === "unlocked" ? "Click canvas for mouse look" : "Mouse look unavailable";
+  }
+
+  update({ supported: true, locked: false });
+
+  return {
+    element,
+    update
+  };
+}

--- a/tests/app/inputController.test.ts
+++ b/tests/app/inputController.test.ts
@@ -6,11 +6,16 @@ import {
   type InputActions
 } from "../../src/app/inputController";
 import {
+  lookIntent,
   mineIntent,
   moveIntent,
   placeIntent,
   selectHotbarIntent
 } from "../../src/input/intents";
+import type {
+  PointerLockAdapter,
+  PointerLockLookDeltaHandler
+} from "../../src/input/pointerLock";
 
 class FakeEventSource {
   private readonly listeners = new Map<string, Set<EventListener>>();
@@ -54,6 +59,38 @@ class FakeCanvas extends FakeEventSource {
   }
 }
 
+class FakePointerLockAdapter implements PointerLockAdapter {
+  disposed = false;
+  locked = false;
+  private readonly lookHandlers = new Set<PointerLockLookDeltaHandler>();
+
+  isLocked(): boolean {
+    return this.locked;
+  }
+
+  emitLookDelta(movementX: number, movementY: number): void {
+    for (const handler of this.lookHandlers) {
+      handler({ type: "look-delta", movementX, movementY });
+    }
+  }
+
+  on(handler: PointerLockLookDeltaHandler): () => void {
+    this.lookHandlers.add(handler);
+    return () => {
+      this.lookHandlers.delete(handler);
+    };
+  }
+
+  off(handler: PointerLockLookDeltaHandler): void {
+    this.lookHandlers.delete(handler);
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.lookHandlers.clear();
+  }
+}
+
 interface KeyboardEventInitLike {
   readonly code: string;
   readonly key: string;
@@ -77,7 +114,7 @@ function syntheticMouseEvent(type: "mousedown" | "contextmenu", button = 0): Mou
   return event;
 }
 
-function createSubject(): {
+function createSubject(pointerLock?: PointerLockAdapter | null): {
   readonly actions: InputActions;
   readonly canvas: FakeCanvas;
   readonly input: ReturnType<typeof createInputController>;
@@ -89,7 +126,9 @@ function createSubject(): {
     onToggleCrafting: vi.fn(),
     onSave: vi.fn()
   };
-  const input = createInputController(canvas.asHtmlCanvasElement(), actions);
+  const input = createInputController(canvas.asHtmlCanvasElement(), actions, {
+    pointerLock
+  });
 
   return { actions, canvas, input, view };
 }
@@ -138,6 +177,32 @@ describe("input controller", () => {
       actions: [mineIntent(), placeIntent()]
     });
     expect(nextFrameIntents(input).actions).toEqual([]);
+  });
+
+  it("drains pointer lock look deltas without blocking movement or mouse actions", () => {
+    const pointerLock = new FakePointerLockAdapter();
+    const { canvas, input, view } = createSubject(pointerLock);
+    const mineEvent = syntheticMouseEvent("mousedown", 0);
+
+    expect(input.isPointerLockSupported()).toBe(true);
+    expect(input.isPointerLocked()).toBe(false);
+
+    view.dispatch("keydown", syntheticKeyboardEvent("keydown", { code: "KeyW", key: "w" }));
+    pointerLock.locked = true;
+    pointerLock.emitLookDelta(4, -3);
+    canvas.dispatch("mousedown", mineEvent);
+
+    expect(input.isPointerLocked()).toBe(true);
+    expect(nextFrameIntents(input)).toEqual({
+      move: moveIntent(1, 0, 0, false),
+      look: lookIntent(4, -3),
+      actions: [mineIntent()]
+    });
+    expect(nextFrameIntents(input).look).toBeNull();
+
+    input.dispose();
+
+    expect(pointerLock.disposed).toBe(true);
   });
 
   it("creates hotbar selection actions from digit codes and digit keys", () => {
@@ -220,6 +285,13 @@ describe("input controller", () => {
     });
   });
 
+  it("reports unsupported pointer lock when no adapter is available", () => {
+    const { input } = createSubject(null);
+
+    expect(input.isPointerLockSupported()).toBe(false);
+    expect(input.isPointerLocked()).toBe(false);
+  });
+
   it("removes every listener on dispose and ignores later events", () => {
     const { actions, canvas, input, view } = createSubject();
 
@@ -255,4 +327,5 @@ describe("input controller", () => {
       actions: []
     });
   });
+
 });

--- a/tests/hud/pointerLockHint.test.ts
+++ b/tests/hud/pointerLockHint.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { createPointerLockHint } from "../../src/hud/pointerLockHint";
+
+describe("pointer lock hint", () => {
+  it("creates a stable selector and updates pointer lock states", () => {
+    const hint = createPointerLockHint();
+
+    expect(hint.element.dataset.testid).toBe("hud-pointer-lock-hint");
+    expect(hint.element.dataset.state).toBe("unlocked");
+    expect(hint.element.textContent).toBe("Click canvas for mouse look");
+
+    hint.update({ supported: true, locked: true });
+
+    expect(hint.element.dataset.state).toBe("locked");
+    expect(hint.element.textContent).toBe("Pointer locked");
+
+    hint.update({ supported: false, locked: false });
+
+    expect(hint.element.dataset.state).toBe("unsupported");
+    expect(hint.element.textContent).toBe("Mouse look unavailable");
+  });
+});

--- a/tests/input/pointerLock.test.ts
+++ b/tests/input/pointerLock.test.ts
@@ -113,7 +113,7 @@ describe("pointer lock adapter", () => {
   it("requests pointer lock when the target is clicked", () => {
     const target = new FakePointerLockTarget();
     const pointerLockDocument = new FakePointerLockDocument();
-    const adapter = createPointerLock(target, { document: pointerLockDocument });
+    const adapter = createPointerLock(target, pointerLockDocument);
 
     target.dispatch("click", new Event("click"));
 


### PR DESCRIPTION
## Surface pointer lock state in input controller and HUD hint

**Category:** `feature` | **Contributor:** rc5aXQArXebGxCxzFJJ24

Closes #286

### Changes
Wire pointer lock state into app input and HUD. Add a testable pointer lock hint, preserve existing keyboard/mouse behavior, and keep createPointerLock backward compatible.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*