### PR TITLE
Fix crafting overlay pointer lock MVP gate

### DIFF
--- a/src/app/hud.ts
+++ b/src/app/hud.ts
@@ -34,6 +34,7 @@ export function createHud(simulation: Simulation, hotbar: Hotbar): HudElements {
   root.dataset.testid = "hud-root";
   root.style.position = "absolute";
   root.style.inset = "0";
+  root.style.zIndex = "1";
   root.style.pointerEvents = "none";
   root.style.color = "#f8fafc";
   root.style.font = "14px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace";

--- a/src/app/inputController.ts
+++ b/src/app/inputController.ts
@@ -74,6 +74,7 @@ export function createInputController(
 
     if (event.code === "KeyE" || event.key.toLowerCase() === "e") {
       event.preventDefault();
+      releasePointerLock();
       actions.onToggleCrafting();
       return;
     }
@@ -82,6 +83,14 @@ export function createInputController(
       event.preventDefault();
       actions.onSave();
     }
+  }
+
+  function releasePointerLock(): void {
+    if (pointerLock?.isLocked() !== true) {
+      return;
+    }
+
+    canvas.ownerDocument.exitPointerLock();
   }
 
   function handleKeyUp(event: KeyboardEvent): void {

--- a/tests/app/hud.test.ts
+++ b/tests/app/hud.test.ts
@@ -51,6 +51,9 @@ describe("app HUD assembly", () => {
     expect(getByTestId(hud.root, "hud-inventory")).toBe(hud.inventoryPanel.element);
     expect(getByTestId(hud.root, "hud-crafting-panel")).toBe(hud.craftingPanel.element);
     expect(getByTestId(hud.root, "hud-world-status")).toBe(hud.worldStatus);
+    expect(hud.root.style.zIndex).toBe("1");
+    expect(hud.root.style.pointerEvents).toBe("none");
+    expect(hud.craftingPanel.element.style.pointerEvents).toBe("auto");
   });
 
   it("updates coordinates and the selected hotbar slot from new state", () => {

--- a/tests/app/inputController.test.ts
+++ b/tests/app/inputController.test.ts
@@ -42,12 +42,15 @@ class FakeEventSource {
 }
 
 class FakeCanvas extends FakeEventSource {
-  readonly ownerDocument: { readonly defaultView: FakeEventSource | null };
+  readonly ownerDocument: {
+    readonly defaultView: FakeEventSource | null;
+    exitPointerLock: ReturnType<typeof vi.fn>;
+  };
   focusCalls = 0;
 
   constructor(defaultView: FakeEventSource | null = new FakeEventSource()) {
     super();
-    this.ownerDocument = { defaultView };
+    this.ownerDocument = { defaultView, exitPointerLock: vi.fn() };
   }
 
   focus(): void {
@@ -257,6 +260,19 @@ describe("input controller", () => {
     expect(craftingEvent.defaultPrevented).toBe(true);
     expect(saveEvent.defaultPrevented).toBe(true);
     expect(nextFrameIntents(input).actions).toEqual([]);
+  });
+
+  it("exits pointer lock before opening the crafting overlay", () => {
+    const pointerLock = new FakePointerLockAdapter();
+    const { actions, canvas, view } = createSubject(pointerLock);
+    const event = syntheticKeyboardEvent("keydown", { code: "KeyE", key: "e" });
+
+    pointerLock.locked = true;
+    view.dispatch("keydown", event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(canvas.ownerDocument.exitPointerLock).toHaveBeenCalledTimes(1);
+    expect(actions.onToggleCrafting).toHaveBeenCalledTimes(1);
   });
 
   it("prevents the canvas context menu while active", () => {

--- a/tests/e2e/mvp.spec.ts
+++ b/tests/e2e/mvp.spec.ts
@@ -65,6 +65,10 @@ test("satisfies the constitution MVP gameplay loop", async ({ page }) => {
     })
     .not.toBe(initialCoordinates);
 
+  await page.reload();
+  await expect(page.locator("[data-testid='canvas-host']")).toBeVisible();
+  await expect(page.locator("[data-testid='hud-hotbar']")).toBeVisible();
+
   await page.mouse.click(400, 300, { button: "left" });
   await expect(page.locator("[data-testid='hud-world-status']")).toContainText(/mined/i);
 


### PR DESCRIPTION
## Summary
- release pointer lock before opening the crafting overlay so HUD clicks reach recipe rows
- make HUD layering explicit above the renderer
- harden the MVP Playwright gate by separating movement verification from the fixed mine/place/craft/save loop

## Verification
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm exec playwright test